### PR TITLE
Fix filename typo in logs.py

### DIFF
--- a/src/linux_mcp_server/tools/logs.py
+++ b/src/linux_mcp_server/tools/logs.py
@@ -93,7 +93,7 @@ async def get_audit_logs(
     # Validate lines parameter (accepts floats from LLMs)
     lines, _ = validate_line_count(lines, default=100)
 
-    audit_log_path = "/var/log/audit/audilog"
+    audit_log_path = "/var/log/audit/audit.log"
 
     try:
         # For local execution, check if file exists


### PR DESCRIPTION
filename typo causing logic error

Related to #16.