### PR TITLE
Correct enum value for tool call complete

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -78,7 +78,7 @@ async def _execute_tool(tool_name: str, handler, **kwargs):
     try:
         result = await handler(**kwargs)
         duration = time.time() - start_time
-        log_tool_complete(tool_name, status="success", duration=duration)
+        log_tool_complete(tool_name, status=Status.success, duration=duration)
         return result
     except Exception as e:
         duration = time.time() - start_time

--- a/src/linux_mcp_server/audit.py
+++ b/src/linux_mcp_server/audit.py
@@ -43,12 +43,17 @@ class Event(StrEnum):
     SSH_CONNECT = "SSH_CONNECT"
     SSH_CONNECTING = "SSH_CONNECTING"
     TOOL_CALL = "TOOL_CALL"
-    TOOL_COMPLETE = "TOOL_CALL"
+    TOOL_COMPLETE = "TOOL_COMPLETE"
 
 
 class ExecutionMode(StrEnum):
     REMOTE = "REMOTE"
     LOCAL = "LOCAL"
+
+
+class Status(StrEnum):
+    success = "success"
+    error = "error"
 
 
 def sanitize_parameters(params: dict[str, t.Any]) -> dict[str, t.Any]:
@@ -160,7 +165,7 @@ def _log_event_complete(
     """
     stop_time = time.perf_counter_ns()
     duration = timedelta(microseconds=(stop_time - start_time) / 1_000)
-    status = "error" if error else "success"
+    status = Status.error if error else Status.success
     extra = {
         "tool": tool_name,
         "status": status,
@@ -249,7 +254,7 @@ def log_ssh_connect(
 
     user_host = f"{username}@{host}"
 
-    if status == "success":
+    if status == Status.success:
         extra = {
             "host": host,
             "username": username,

--- a/src/linux_mcp_server/tools/ssh_executor.py
+++ b/src/linux_mcp_server/tools/ssh_executor.py
@@ -23,6 +23,7 @@ import asyncssh
 from linux_mcp_server.audit import Event
 from linux_mcp_server.audit import log_ssh_command
 from linux_mcp_server.audit import log_ssh_connect
+from linux_mcp_server.audit import Status
 
 
 logger = logging.getLogger("linux-mcp-server")
@@ -118,7 +119,7 @@ class SSHConnectionManager:
                 # DEBUG level: Log connection reuse and pool state
                 logger.debug(f"SSH_REUSE: {key} | pool_size={len(self._connections)}")
                 # Use audit log with connection reuse info
-                log_ssh_connect(host, username, status="success", reused=True, key_path=self._ssh_key)
+                log_ssh_connect(host, username, status=Status.success, reused=True, key_path=self._ssh_key)
                 return conn
             else:
                 # Connection was closed, remove it
@@ -143,7 +144,7 @@ class SSHConnectionManager:
             self._connections[key] = conn
 
             # Log successful connection using audit function
-            log_ssh_connect(host, username, status="success", reused=False, key_path=self._ssh_key)
+            log_ssh_connect(host, username, status=Status.success, reused=False, key_path=self._ssh_key)
 
             # DEBUG level: Log pool state
             logger.debug(f"SSH_POOL: add_connection | connections={len(self._connections)}")

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -11,6 +11,7 @@ from linux_mcp_server.audit import log_ssh_command
 from linux_mcp_server.audit import log_ssh_connect
 from linux_mcp_server.audit import sanitize_parameters
 from linux_mcp_server.audit import SENSITIVE_FIELDS
+from linux_mcp_server.audit import Status
 
 
 class TestSanitizeParameters:
@@ -190,7 +191,7 @@ class TestLogSSHConnect:
     def test_log_ssh_connect_success_info(self, caplog):
         """Test logging successful SSH connection at INFO level."""
         with caplog.at_level(logging.INFO):
-            log_ssh_connect("server1.com", "admin", status="success", reused=False)
+            log_ssh_connect("server1.com", "admin", status=Status.success, reused=False)
 
         assert Event.SSH_CONNECT in caplog.text
         assert "admin@server1.com" in caplog.text
@@ -208,7 +209,9 @@ class TestLogSSHConnect:
         logging.getLogger().setLevel(logging.DEBUG)
 
         with caplog.at_level(logging.DEBUG):
-            log_ssh_connect("server1.com", "admin", status="success", reused=True, key_path="/home/user/.ssh/id_rsa")
+            log_ssh_connect(
+                "server1.com", "admin", status=Status.success, reused=True, key_path="/home/user/.ssh/id_rsa"
+            )
 
         assert Event.SSH_CONNECT in caplog.text
         assert "admin@server1.com" in caplog.text


### PR DESCRIPTION
Use the correct value for `Event.TOOL_COMPLETE` and add another enum for status.