### PR TITLE
Use a smaller interval when determining CPU utilization

### DIFF
--- a/src/linux_mcp_server/tools/system_info.py
+++ b/src/linux_mcp_server/tools/system_info.py
@@ -243,13 +243,13 @@ async def get_cpu_info(  # noqa: C901
                 pass  # CPU frequency might not be available
 
             # CPU usage per core
-            cpu_percent = psutil.cpu_percent(interval=1, percpu=True)
+            cpu_percent = psutil.cpu_percent(interval=0.1, percpu=True)
             info.append("\nCPU Usage per Core:")
             for i, percent in enumerate(cpu_percent):
                 info.append(f"  Core {i}: {percent}%")
 
             # Overall CPU usage
-            overall_cpu = psutil.cpu_percent(interval=1)
+            overall_cpu = psutil.cpu_percent(interval=0.1)
             info.append(f"\nOverall CPU Usage: {overall_cpu}%")
 
             # Load average


### PR DESCRIPTION
The interval value is a bit confusing. According to the docs, it seems like the minimum recommended blocking interval is 0.1.

https://psutil.readthedocs.io/en/latest/index.html#psutil.Process.cpu_percent