### PR TITLE
Adjust error handling in list_directories function

### DIFF
--- a/src/linux_mcp_server/tools/storage.py
+++ b/src/linux_mcp_server/tools/storage.py
@@ -158,8 +158,10 @@ async def list_directories(  # noqa: C901
         username=username,
     )
 
-    if returncode != 0:
-        raise ToolError(f"Error running {command[0]} command: command failed with return code {returncode}")
+    if returncode != 0 and stdout == "":
+        raise ToolError(
+            f"Error running {command[0]} command: command failed with return code {returncode} and no output was returned"
+        )
 
     lines = [line.strip() for line in stdout.strip().splitlines() if line]
 


### PR DESCRIPTION
Raise a ToolError only if the returncode is not zero *and* the collected output is an empty string.