### PR TITLE
Add license property to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pydantic>=2.12.4",
 ]
 dynamic = ["version"]
+license-files = ["LICENSE", "licenses/GPL-3.0.txt"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Environment :: Console",


### PR DESCRIPTION
As indicated by the packaging dot python dot com docs, the license-files can be used when distributing the package to indicate your own license (LICENSE) and the vendored ones.