### PR TITLE
Do not use deprecated method

### DIFF
--- a/src/linux_mcp_server/tools/processes.py
+++ b/src/linux_mcp_server/tools/processes.py
@@ -251,7 +251,7 @@ async def get_process_info(  # noqa: C901
 
             # Connections
             try:
-                connections = proc.connections()
+                connections = proc.net_connections()
                 if connections:
                     info.append(f"\n=== Network Connections ({len(connections)}) ===")
                     for _, conn in enumerate(connections[:10]):  # Show first 10


### PR DESCRIPTION
psutil.Process.connections() was deprecated in 6.0 and we are using 7.x.

https://psutil.readthedocs.io/en/latest/index.html#psutil.Process.connections