### PR TITLE
fix: filter out ipv6 link-local addresses

### DIFF
--- a/src/linux_mcp_server/utils/__init__.py
+++ b/src/linux_mcp_server/utils/__init__.py
@@ -1,2 +1,3 @@
 from linux_mcp_server.utils.enum import StrEnum as StrEnum
 from linux_mcp_server.utils.format import format_bytes as format_bytes
+from linux_mcp_server.utils.format import is_ipv6_link_local

--- a/src/linux_mcp_server/utils/format.py
+++ b/src/linux_mcp_server/utils/format.py
@@ -1,3 +1,38 @@
+import ipaddress
+
+
+def is_ipv6_link_local(address: str) -> bool:
+    """Check if an IPv6 address is link-local (fe80::/10).
+
+    Link-local addresses are only valid on a single network segment and
+    require a scope identifier to route. They're not useful for enterprise
+    cross-machine communication.
+
+    Args:
+        address: IPv6 address string, possibly with scope identifier (e.g., "fe80::1%eth0")
+
+    Returns:
+        True if the address is link-local, False otherwise
+
+    Examples:
+        >>> is_ipv6_link_local("fe80::1")
+        True
+        >>> is_ipv6_link_local("fe80::1%eth0")
+        True
+        >>> is_ipv6_link_local("2001:db8::1")
+        False
+        >>> is_ipv6_link_local("192.168.1.1")
+        False
+    """
+    try:
+        # Parse and check if it's link-local
+        addr = ipaddress.IPv6Address(address)
+        return addr.is_link_local
+    except (ValueError, ipaddress.AddressValueError):
+        # Not a valid IPv6 address (could be IPv4, empty, or malformed)
+        return False
+
+
 def format_bytes(bytes_value: int | float) -> str:
     """
     Format bytes into human-readable format.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,180 @@
+import socket
+
 import pytest
 
 from linux_mcp_server.audit import log_tool_call
+
+
+# =============================================================================
+# Shared test constants for IPv6 link-local filtering tests
+# =============================================================================
+LINK_LOCAL_IPV6 = "fe80::1%eth0"
+GLOBAL_IPV6 = "2001:db8::1"
+IPV4_ADDR = "192.168.1.100"
+
+# Parameterized test cases for link-local address filtering (process tests)
+# Format: (laddr_ip, raddr_ip, expectation)
+# Each expectation is a string that will be eval'd with result, laddr_ip in scope
+LINK_LOCAL_FILTER_CASES_PROCESS = [
+    pytest.param(LINK_LOCAL_IPV6, IPV4_ADDR, '"Network Connections" not in result', id="laddr-link-local"),
+    pytest.param(IPV4_ADDR, LINK_LOCAL_IPV6, '"Network Connections" not in result', id="raddr-link-local"),
+    pytest.param(LINK_LOCAL_IPV6, LINK_LOCAL_IPV6, '"Network Connections" not in result', id="both-link-local"),
+    pytest.param(IPV4_ADDR, GLOBAL_IPV6, '"Network Connections (1)" in result', id="no-link-local-header"),
+    pytest.param(IPV4_ADDR, GLOBAL_IPV6, 'f"{laddr_ip}:8080" in result', id="no-link-local-addr"),
+    pytest.param(GLOBAL_IPV6, IPV4_ADDR, '"Network Connections (1)" in result', id="global-ipv6-header"),
+    pytest.param(GLOBAL_IPV6, IPV4_ADDR, 'f"{laddr_ip}:8080" in result', id="global-ipv6-addr"),
+]
+
+# Parameterized test cases for link-local address filtering (network tests)
+# Format: (laddr_ip, raddr_ip, expectation)
+# Each expectation is a string that will be eval'd with output in scope
+LINK_LOCAL_FILTER_CASES_NETWORK = [
+    pytest.param(LINK_LOCAL_IPV6, IPV4_ADDR, '"filtered 1 link-local" in output', id="laddr-link-local-filtered"),
+    pytest.param(LINK_LOCAL_IPV6, IPV4_ADDR, '"Total connections: 0" in output', id="laddr-link-local-count"),
+    pytest.param(IPV4_ADDR, LINK_LOCAL_IPV6, '"filtered 1 link-local" in output', id="raddr-link-local-filtered"),
+    pytest.param(IPV4_ADDR, LINK_LOCAL_IPV6, '"Total connections: 0" in output', id="raddr-link-local-count"),
+    pytest.param(LINK_LOCAL_IPV6, LINK_LOCAL_IPV6, '"filtered 1 link-local" in output', id="both-link-local-filtered"),
+    pytest.param(LINK_LOCAL_IPV6, LINK_LOCAL_IPV6, '"Total connections: 0" in output', id="both-link-local-count"),
+    pytest.param(IPV4_ADDR, GLOBAL_IPV6, '"filtered" not in output', id="no-link-local-not-filtered"),
+    pytest.param(IPV4_ADDR, GLOBAL_IPV6, '"Total connections: 1" in output', id="no-link-local-count"),
+    pytest.param(GLOBAL_IPV6, IPV4_ADDR, '"filtered" not in output', id="global-ipv6-not-filtered"),
+    pytest.param(GLOBAL_IPV6, IPV4_ADDR, '"Total connections: 1" in output', id="global-ipv6-count"),
+]
+
+
+# =============================================================================
+# Shared mock classes for network/connection testing
+# =============================================================================
+class MockAddr:
+    """Mock address for network connections (ip:port)."""
+
+    def __init__(self, ip: str, port: int):
+        self.ip = ip
+        self.port = port
+
+
+class MockConnectionType:
+    """Mock socket type with name attribute (for process connections)."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+
+class MockConnection:
+    """Mock network connection - works for both network tools and process tools.
+
+    For network tools: pass type_ as socket.SOCK_STREAM/SOCK_DGRAM
+    For process tools: pass type_name as "SOCK_STREAM"/"SOCK_DGRAM"
+    """
+
+    def __init__(
+        self,
+        type_=None,
+        type_name: str | None = None,
+        laddr: MockAddr | None = None,
+        raddr: MockAddr | None = None,
+        status: str | None = "ESTABLISHED",
+        pid: int | None = None,
+    ):
+        # Support both network-style (type_) and process-style (type_name)
+        if type_name is not None:
+            self.type = MockConnectionType(type_name)
+        else:
+            self.type = type_ if type_ is not None else socket.SOCK_STREAM
+        self.laddr = laddr
+        self.raddr = raddr
+        self.status = status
+        self.pid = pid
+
+
+# =============================================================================
+# Shared test data for mixed link-local filtering scenarios
+# =============================================================================
+def make_mixed_connections_network():
+    """Create mixed connections for network tool tests (with pid)."""
+    return [
+        # Should be filtered (link-local laddr)
+        MockConnection(
+            type_=socket.SOCK_STREAM,
+            laddr=MockAddr(LINK_LOCAL_IPV6, 8080),
+            raddr=MockAddr(IPV4_ADDR, 54321),
+            status="ESTABLISHED",
+            pid=1234,
+        ),
+        # Should be shown (IPv4 -> global IPv6)
+        MockConnection(
+            type_=socket.SOCK_STREAM,
+            laddr=MockAddr(IPV4_ADDR, 80),
+            raddr=MockAddr(GLOBAL_IPV6, 12345),
+            status="ESTABLISHED",
+            pid=5678,
+        ),
+        # Should be filtered (link-local raddr)
+        MockConnection(
+            type_=socket.SOCK_DGRAM,
+            laddr=MockAddr(IPV4_ADDR, 53),
+            raddr=MockAddr(LINK_LOCAL_IPV6, 9999),
+            status=None,
+            pid=9999,
+        ),
+    ]
+
+
+def make_mixed_listening_ports():
+    """Create mixed listening ports for filtering tests (with pid)."""
+    return [
+        # Should be filtered (link-local)
+        MockConnection(
+            type_=socket.SOCK_STREAM,
+            laddr=MockAddr(LINK_LOCAL_IPV6, 8080),
+            raddr=None,
+            status="LISTEN",
+            pid=1234,
+        ),
+        # Should be shown (IPv4)
+        MockConnection(
+            type_=socket.SOCK_STREAM,
+            laddr=MockAddr(IPV4_ADDR, 80),
+            raddr=None,
+            status="LISTEN",
+            pid=5678,
+        ),
+        # Should be shown (global IPv6)
+        MockConnection(
+            type_=socket.SOCK_DGRAM,
+            laddr=MockAddr(GLOBAL_IPV6, 53),
+            raddr=None,
+            status=None,
+            pid=9999,
+        ),
+    ]
+
+
+def make_mixed_connections_process():
+    """Create mixed connections for process tool tests (with type_name)."""
+    return [
+        # Should be filtered (link-local laddr)
+        MockConnection(
+            type_name="SOCK_STREAM",
+            laddr=MockAddr(LINK_LOCAL_IPV6, 8080),
+            raddr=MockAddr(IPV4_ADDR, 54321),
+            status="ESTABLISHED",
+        ),
+        # Should be shown
+        MockConnection(
+            type_name="SOCK_STREAM",
+            laddr=MockAddr(IPV4_ADDR, 80),
+            raddr=MockAddr(GLOBAL_IPV6, 12345),
+            status="ESTABLISHED",
+        ),
+        # Should be filtered (link-local raddr)
+        MockConnection(
+            type_name="SOCK_DGRAM",
+            laddr=MockAddr(IPV4_ADDR, 53),
+            raddr=MockAddr(LINK_LOCAL_IPV6, 9999),
+            status="NONE",
+        ),
+    ]
 
 
 @pytest.fixture

--- a/tests/tools/test_processes.py
+++ b/tests/tools/test_processes.py
@@ -2,7 +2,18 @@
 
 import os
 
+from unittest.mock import MagicMock
+
+import pytest
+
 from linux_mcp_server.tools import processes
+from tests.conftest import GLOBAL_IPV6
+from tests.conftest import IPV4_ADDR
+from tests.conftest import LINK_LOCAL_FILTER_CASES_PROCESS
+from tests.conftest import LINK_LOCAL_IPV6
+from tests.conftest import make_mixed_connections_process
+from tests.conftest import MockAddr
+from tests.conftest import MockConnection
 
 
 class TestProcesses:
@@ -55,3 +66,130 @@ class TestProcesses:
         result = await processes.list_processes(host="starship.command")
 
         assert "Running Processes" in result
+
+
+@pytest.fixture
+def create_mock_process():
+    """Factory fixture to create a mock process with configurable network connections."""
+
+    def _create(connections):
+        mock_proc = MagicMock()
+        mock_proc.name.return_value = "test_process"
+        mock_proc.exe.return_value = "/usr/bin/test"
+        mock_proc.cmdline.return_value = ["test", "--arg"]
+        mock_proc.status.return_value = "running"
+        mock_proc.username.return_value = "testuser"
+        mock_proc.pid = 12345
+        mock_proc.ppid.return_value = 1
+        mock_proc.cpu_percent.return_value = 1.5
+        mock_proc.memory_percent.return_value = 2.0
+        mock_proc.memory_info.return_value = MagicMock(rss=1024 * 1024, vms=2048 * 1024)
+        mock_proc.create_time.return_value = 1700000000.0
+        mock_proc.cpu_times.return_value = MagicMock(user=10.0, system=5.0)
+        mock_proc.num_threads.return_value = 4
+        mock_proc.num_fds.return_value = 10
+        mock_proc.net_connections.return_value = connections
+        return mock_proc
+
+    return _create
+
+
+class TestGetProcessInfoLinkLocalFiltering:
+    """Test get_process_info filters link-local connections."""
+
+    @pytest.mark.parametrize("laddr_ip,raddr_ip,expectation", LINK_LOCAL_FILTER_CASES_PROCESS)
+    async def test_get_process_info_filters_link_local_connections(
+        self, mocker, create_mock_process, laddr_ip, raddr_ip, expectation
+    ):
+        """Test that process connections with link-local addresses are filtered."""
+        connections = [
+            MockConnection(
+                type_name="SOCK_STREAM",
+                laddr=MockAddr(laddr_ip, 8080),
+                raddr=MockAddr(raddr_ip, 54321),
+                status="ESTABLISHED",
+            ),
+        ]
+
+        mock_proc = create_mock_process(connections)
+        mocker.patch.object(processes.psutil, "pid_exists", return_value=True)
+        mocker.patch.object(processes.psutil, "Process", return_value=mock_proc)
+
+        result = await processes.get_process_info(12345)  # noqa: F841 - used in eval
+
+        assert eval(expectation)
+
+    async def test_get_process_info_mixed_connections_filtering(self, mocker, create_mock_process):
+        """Test filtering with mix of link-local and regular connections."""
+        mock_proc = create_mock_process(make_mixed_connections_process())
+        mocker.patch.object(processes.psutil, "pid_exists", return_value=True)
+        mocker.patch.object(processes.psutil, "Process", return_value=mock_proc)
+
+        result = await processes.get_process_info(12345)
+
+        # Should only show 1 connection (the IPv4 -> global IPv6 one)
+        assert "Network Connections (1)" in result
+        assert f"{IPV4_ADDR}:80" in result
+        assert f"{GLOBAL_IPV6}:12345" in result
+        # Link-local addresses should not appear
+        assert LINK_LOCAL_IPV6 not in result
+
+    async def test_get_process_info_shows_more_than_10_connections_message(self, mocker, create_mock_process):
+        """Test that 'and X more' message shows correct count after filtering."""
+        # Create 15 regular connections (should show "and 5 more")
+        connections = [
+            MockConnection(
+                type_name="SOCK_STREAM",
+                laddr=MockAddr(IPV4_ADDR, 8000 + i),
+                raddr=MockAddr(GLOBAL_IPV6, 50000 + i),
+                status="ESTABLISHED",
+            )
+            for i in range(15)
+        ]
+        # Add 5 link-local connections that should be filtered out
+        connections.extend(
+            [
+                MockConnection(
+                    type_name="SOCK_STREAM",
+                    laddr=MockAddr(LINK_LOCAL_IPV6, 9000 + i),
+                    raddr=MockAddr(IPV4_ADDR, 60000 + i),
+                    status="ESTABLISHED",
+                )
+                for i in range(5)
+            ]
+        )
+
+        mock_proc = create_mock_process(connections)
+        mocker.patch.object(processes.psutil, "pid_exists", return_value=True)
+        mocker.patch.object(processes.psutil, "Process", return_value=mock_proc)
+
+        result = await processes.get_process_info(12345)
+
+        # Should show 15 filtered connections, first 10 displayed, "and 5 more"
+        assert "Network Connections (15)" in result
+        assert "... and 5 more" in result
+
+    @pytest.mark.parametrize(
+        "laddr,raddr,expected_local,expected_remote",
+        [
+            pytest.param(MockAddr(IPV4_ADDR, 80), None, f"{IPV4_ADDR}:80", "N/A", id="no-raddr"),
+            pytest.param(None, MockAddr(IPV4_ADDR, 80), "N/A", f"{IPV4_ADDR}:80", id="no-laddr"),
+        ],
+    )
+    async def test_get_process_info_connection_missing_address(
+        self, mocker, create_mock_process, laddr, raddr, expected_local, expected_remote
+    ):
+        """Test connections with missing local or remote address."""
+        connections = [
+            MockConnection(type_name="SOCK_STREAM", laddr=laddr, raddr=raddr, status="ESTABLISHED"),
+        ]
+
+        mock_proc = create_mock_process(connections)
+        mocker.patch.object(processes.psutil, "pid_exists", return_value=True)
+        mocker.patch.object(processes.psutil, "Process", return_value=mock_proc)
+
+        result = await processes.get_process_info(12345)
+
+        assert "Network Connections (1)" in result
+        assert expected_local in result
+        assert expected_remote in result

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -1,6 +1,7 @@
 import pytest
 
 from linux_mcp_server.utils.format import format_bytes
+from linux_mcp_server.utils.format import is_ipv6_link_local
 
 
 @pytest.mark.parametrize(
@@ -18,5 +19,50 @@ from linux_mcp_server.utils.format import format_bytes
 )
 def test_format_bytes(value, expected):
     result = format_bytes(value)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("address", "expected"),
+    (
+        # Link-local addresses - fe80::/10 covers fe80:: through febf::
+        ("fe80::1", True),
+        ("fe80::1%eth0", True),  # With scope identifier
+        ("fe80::abcd:1234%enp0s3", True),
+        ("FE80::1", True),  # Uppercase
+        ("fe80::", True),
+        ("fe81::1", True),  # fe8x range
+        ("fe8f::1", True),
+        ("fe90::1", True),  # fe9x range
+        ("fe9f::1", True),
+        ("fea0::1", True),  # feax range
+        ("feaf::1", True),
+        ("feb0::1", True),  # febx range
+        ("febf::1", True),  # Last in range
+        ("fe80::1:2:3:4", True),  # Full link-local address
+        ("fe80:0000:0000:0000:0000:0000:0000:0001", True),  # Expanded form
+        ("febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff", True),  # Upper boundary
+        # Non-link-local addresses (should return False)
+        ("fec0::1", False),  # Site-local (just outside range)
+        ("ff00::1", False),  # Multicast
+        ("::1", False),  # Loopback
+        ("2001:db8::1", False),  # Documentation range
+        ("2001:0db8:85a3:0000:0000:8a2e:0370:7334", False),
+        ("", False),  # Empty string
+        # IPv4 addresses (should return False)
+        ("192.168.1.1", False),
+        ("127.0.0.1", False),
+        ("169.254.1.1", False),  # IPv4 link-local (different from IPv6)
+        # Malformed inputs (should return False gracefully)
+        ("fe80::xyz", False),  # Invalid hex characters
+        ("fe80:::1", False),  # Malformed triple colon
+        ("not-an-ip", False),  # Completely invalid
+        ("fe80::1::2", False),  # Multiple :: compressions
+        ("fe80:ghij::1", False),  # Invalid hex in middle
+    ),
+)
+def test_is_ipv6_link_local(address, expected):
+    result = is_ipv6_link_local(address)
 
     assert result == expected


### PR DESCRIPTION
IPv6 link-local addresses are automatically assigned but they are poor options for reliable connectivity in an IPv6 network. Filter out these addresses carefully.

Fixes #74