### PR TITLE
refactor(network): extract connection formatting helpers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,6 +177,28 @@ def make_mixed_connections_process():
     ]
 
 
+# =============================================================================
+# Fixtures for network/connection testing
+# =============================================================================
+@pytest.fixture
+def mock_network_process(mocker):
+    """Create a mock psutil.Process that returns a configurable name.
+
+    Usage:
+        def test_something(mock_network_process):
+            mock_network_process("nginx")  # Set the process name
+            # Now psutil.Process(...).name() will return "nginx"
+    """
+    mock_process = mocker.MagicMock()
+
+    def setup_process(name: str = "test"):
+        mock_process.name.return_value = name
+        mocker.patch("linux_mcp_server.tools.network.psutil.Process", return_value=mock_process)
+        return mock_process
+
+    return setup_process
+
+
 @pytest.fixture
 def decorated():
     @log_tool_call


### PR DESCRIPTION
Extract duplicated formatting logic from get_network_connections() and get_listening_ports() into three reusable helper functions:

- _should_filter_connection(): centralized link-local filtering logic
- _build_connection_table_header(): consistent table header generation
- _format_connection_line(): unified connection line formatting

Benefits:
- Eliminates ~25 lines of duplicated code
- Makes filtering logic independently testable
- Consistent formatting across network tools
- Reduces cyclomatic complexity

Also refactor tests:
- Add mock_network_process fixture for test deduplication
- Add extract_tool_output() helper for result extraction
- Merge separate header tests into parameterized test
- Test file reduced by ~22% (1127 -> 878 lines)