### PR TITLE
feat(utils): add command-line sanitization utility

### DIFF
--- a/src/linux_mcp_server/utils/__init__.py
+++ b/src/linux_mcp_server/utils/__init__.py
@@ -1,3 +1,5 @@
 from linux_mcp_server.utils.enum import StrEnum as StrEnum
 from linux_mcp_server.utils.format import format_bytes as format_bytes
 from linux_mcp_server.utils.format import is_ipv6_link_local as is_ipv6_link_local
+from linux_mcp_server.utils.sanitize import REDACTED as REDACTED
+from linux_mcp_server.utils.sanitize import sanitize_cmdline as sanitize_cmdline

--- a/src/linux_mcp_server/utils/sanitize.py
+++ b/src/linux_mcp_server/utils/sanitize.py
@@ -1,0 +1,102 @@
+"""Command-line sanitization utilities to prevent secret exposure."""
+
+# Common flags that precede secrets
+_SECRET_FLAGS: frozenset[str] = frozenset(
+    {
+        "-p",
+        "--password",
+        "--pass",
+        "--passwd",
+        "--secret",
+        "--token",
+        "--api-key",
+        "--api_key",
+        "--apikey",
+        "-k",
+        "--key",
+        "--auth",
+        "--credential",
+        "--private-key",
+        "--secret-key",
+        "--access-key",
+    }
+)
+
+# Patterns in key=value format
+_SECRET_PATTERNS: tuple[str, ...] = (
+    "password=",
+    "passwd=",
+    "pass=",
+    "token=",
+    "secret=",
+    "apikey=",
+    "api_key=",
+    "credential=",
+    "auth=",
+    "key=",
+)
+
+REDACTED = "***REDACTED***"
+
+
+def _is_secret_key_value(arg: str) -> bool:
+    """Check if arg is a key=value pattern containing a secret."""
+    arg_lower = arg.lower()
+    return any(arg_lower.startswith(p) for p in _SECRET_PATTERNS)
+
+
+def _process_arg(arg: str) -> tuple[str, bool]:
+    """Process a single argument for secrets.
+
+    Args:
+        arg: Command line argument to process
+
+    Returns:
+        Tuple of (processed_arg, should_redact_next)
+    """
+    # Secret flag without value (e.g., -p, --password) - redact next arg
+    if arg in _SECRET_FLAGS:
+        return arg, True
+
+    # Handle --flag=value or key=value patterns
+    if "=" in arg:
+        key = arg.split("=", 1)[0]
+        if key in _SECRET_FLAGS or _is_secret_key_value(arg):
+            return f"{key}={REDACTED}", False
+
+    return arg, False
+
+
+def sanitize_cmdline(cmdline: list[str] | None) -> list[str] | None:
+    """Sanitize command line arguments to redact potential secrets.
+
+    Redacts arguments following common secret flags (e.g., -p, --password)
+    and key=value patterns containing sensitive keywords.
+
+    Args:
+        cmdline: List of command line arguments (or None)
+
+    Returns:
+        Sanitized list with secrets replaced by REDACTED, or None if input was None
+
+    Note:
+        Not foolproof - secrets in non-standard formats may still leak.
+        Defense in depth: also ensure logs use sanitize_parameters().
+    """
+    if cmdline is None:
+        return None
+    if not cmdline:
+        return []
+
+    result: list[str] = []
+    redact_next = False
+
+    for arg in cmdline:
+        if redact_next:
+            result.append(REDACTED)
+            redact_next = False
+        else:
+            processed, redact_next = _process_arg(arg)
+            result.append(processed)
+
+    return result

--- a/tests/utils/test_sanitize.py
+++ b/tests/utils/test_sanitize.py
@@ -1,0 +1,174 @@
+"""Tests for command-line sanitization utilities."""
+
+import pytest
+
+from linux_mcp_server.utils.sanitize import REDACTED
+from linux_mcp_server.utils.sanitize import sanitize_cmdline
+
+
+def test_sanitize_cmdline_none():
+    """None input should return None."""
+    result = sanitize_cmdline(None)
+
+    assert result is None
+
+
+def test_sanitize_cmdline_empty():
+    """Empty list should return empty list."""
+    result = sanitize_cmdline([])
+
+    assert result == []
+
+
+def test_sanitize_cmdline_no_secrets():
+    """Command with no secrets should remain unchanged."""
+    cmdline = ["ls", "-la", "/home/user"]
+    result = sanitize_cmdline(cmdline)
+
+    assert result == ["ls", "-la", "/home/user"]
+
+
+@pytest.mark.parametrize(
+    ("cmdline", "expected"),
+    (
+        # Short flag with separate value
+        (
+            ["mysql", "-p", "secretpass", "-u", "admin"],
+            ["mysql", "-p", REDACTED, "-u", "admin"],
+        ),
+        # Long flag with separate value
+        (
+            ["curl", "--password", "mypass", "http://example.com"],
+            ["curl", "--password", REDACTED, "http://example.com"],
+        ),
+        # Long flag with equals
+        (
+            ["curl", "--password=mypass", "http://example.com"],
+            ["curl", f"--password={REDACTED}", "http://example.com"],
+        ),
+        # Mixed case in key=value pattern
+        (
+            ["app", "PASSWORD=secret123"],
+            ["app", f"PASSWORD={REDACTED}"],
+        ),
+        # Token pattern
+        (
+            ["gh", "auth", "login", "--token=ghp_1234567890abcdef"],
+            ["gh", "auth", "login", f"--token={REDACTED}"],
+        ),
+        # API key pattern with underscore
+        (
+            ["script.py", "--api_key=sk-1234567890"],
+            ["script.py", f"--api_key={REDACTED}"],
+        ),
+        # Multiple secrets
+        (
+            ["db", "-p", "dbpass", "--token=abc123", "connect"],
+            ["db", "-p", REDACTED, f"--token={REDACTED}", "connect"],
+        ),
+        # Secret flag at end (no value to redact)
+        (
+            ["cmd", "arg1", "-p"],
+            ["cmd", "arg1", "-p"],
+        ),
+        # Various secret flags
+        (
+            ["app", "--secret", "s3cr3t"],
+            ["app", "--secret", REDACTED],
+        ),
+        (
+            ["app", "-k", "mykey"],
+            ["app", "-k", REDACTED],
+        ),
+        (
+            ["app", "--apikey", "key123"],
+            ["app", "--apikey", REDACTED],
+        ),
+        (
+            ["app", "--auth", "bearer token"],
+            ["app", "--auth", REDACTED],
+        ),
+        (
+            ["app", "--credential", "cred123"],
+            ["app", "--credential", REDACTED],
+        ),
+        (
+            ["app", "--private-key", "/path/to/key"],
+            ["app", "--private-key", REDACTED],
+        ),
+        # Key=value patterns
+        (
+            ["app", "pass=secret"],
+            ["app", f"pass={REDACTED}"],
+        ),
+        (
+            ["app", "passwd=secret"],
+            ["app", f"passwd={REDACTED}"],
+        ),
+        (
+            ["app", "secret=value"],
+            ["app", f"secret={REDACTED}"],
+        ),
+        (
+            ["app", "apikey=123"],
+            ["app", f"apikey={REDACTED}"],
+        ),
+        (
+            ["app", "credential=xyz"],
+            ["app", f"credential={REDACTED}"],
+        ),
+        (
+            ["app", "auth=bearer"],
+            ["app", f"auth={REDACTED}"],
+        ),
+        (
+            ["app", "key=value"],
+            ["app", f"key={REDACTED}"],
+        ),
+        # Edge case: equals with empty value
+        (
+            ["app", "password="],
+            ["app", f"password={REDACTED}"],
+        ),
+        # Non-secret flags that contain secret words but aren't exact matches
+        (
+            ["app", "--pass-through", "value"],
+            ["app", "--pass-through", "value"],
+        ),
+        # Non-secret key=value patterns should remain unchanged
+        (
+            ["app", "--verbose=true", "mode=debug"],
+            ["app", "--verbose=true", "mode=debug"],
+        ),
+        # Complex real-world example
+        (
+            [
+                "ssh",
+                "-i",
+                "/path/to/key",
+                "user@host",
+                "mysql",
+                "-u",
+                "root",
+                "-p",
+                "dbpass",
+            ],
+            [
+                "ssh",
+                "-i",
+                "/path/to/key",
+                "user@host",
+                "mysql",
+                "-u",
+                "root",
+                "-p",
+                REDACTED,
+            ],
+        ),
+    ),
+)
+def test_sanitize_cmdline_secrets(cmdline, expected):
+    """Various secret formats should be properly redacted."""
+    result = sanitize_cmdline(cmdline)
+
+    assert result == expected


### PR DESCRIPTION
Add sanitize_cmdline() function to redact potential secrets from command-line arguments before display. This prevents accidental exposure of passwords, API keys, and tokens in process listings.

Handles:
- Flag-style secrets (-p, --password, --token, etc.)
- Key=value patterns (password=, api_key=, etc.)
- Both separate values and --flag=value syntax
- Case-insensitive matching