### PR TITLE
feat(storage): replace SSH commands with Ansible modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "bcrypt",
     "pydantic-settings>=2.12.0",
     "pydantic>=2.12.4",
+    "ansible-core>=2.15.0,<3.0",
+    "ansible-runner>=2.3.0,<3.0",
 ]
 dynamic = ["version"]
 license-files = ["LICENSE", "licenses/GPL-3.0.txt"]

--- a/src/linux_mcp_server/connection/ansible.py
+++ b/src/linux_mcp_server/connection/ansible.py
@@ -1,0 +1,301 @@
+"""Ansible executor for remote command execution.
+
+This module provides functionality to execute Ansible modules on remote systems,
+offering structured output and distribution abstraction as an alternative to raw
+SSH commands.
+"""
+
+import asyncio
+import atexit
+import logging
+import os
+import tempfile
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import ansible_runner
+
+from linux_mcp_server.config import CONFIG
+from linux_mcp_server.connection.ssh import discover_ssh_key
+
+
+logger = logging.getLogger("linux-mcp-server")
+
+
+class AnsibleExecutionError(Exception):
+    """Raised when Ansible module execution fails."""
+
+
+class AnsibleExecutor:
+    """Execute Ansible modules asynchronously with connection pooling.
+
+    This class wraps ansible-runner to provide async execution of Ansible modules
+    while maintaining compatibility with the FastMCP async event loop. It uses a
+    thread pool to run synchronous ansible-runner operations without blocking.
+
+    Features:
+    - Automatic SSH connection pooling via Ansible's ControlPersist
+    - Structured JSON output from Ansible modules (no text parsing)
+    - Distribution abstraction (RHEL/Fedora/CentOS handled automatically)
+    - Comprehensive error handling with audit logging
+
+    Example:
+        executor = AnsibleExecutor()
+        result = await executor.run_module(
+            module="setup",
+            module_args={"gather_subset": ["!all", "!min", "devices"]},
+            host="server.example.com",
+            username="admin"
+        )
+        devices = result["ansible_facts"]["ansible_devices"]
+    """
+
+    def __init__(self, max_workers: int = 4):
+        """Initialize Ansible executor with thread pool.
+
+        Args:
+            max_workers: Number of threads for concurrent Ansible executions
+        """
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        self._ssh_key = discover_ssh_key()
+        self._shutdown = False
+        atexit.register(self.shutdown)
+        logger.debug(
+            f"AnsibleExecutor initialized | workers={max_workers} | key={'<configured>' if self._ssh_key else 'none'}"
+        )
+
+    @staticmethod
+    def _format_module_args(module_args: dict[str, Any] | str | None) -> str:
+        """Convert module arguments to Ansible string format.
+
+        ansible-runner expects module_args as a string in key=value format.
+        This method converts dict arguments to the appropriate string format.
+
+        Args:
+            module_args: Dict, string, or None
+
+        Returns:
+            String in Ansible key=value format
+        """
+        if module_args is None:
+            return ""
+        if isinstance(module_args, str):
+            return module_args
+
+        parts = []
+        for key, value in module_args.items():
+            if isinstance(value, list):
+                # Convert list to comma-separated string
+                formatted_value = ",".join(str(v) for v in value)
+            elif isinstance(value, bool):
+                formatted_value = str(value).lower()
+            else:
+                formatted_value = str(value)
+            parts.append(f"{key}='{formatted_value}'")
+
+        return " ".join(parts)
+
+    async def run_module(
+        self,
+        module: str,
+        module_args: dict[str, Any] | str | None = None,
+        host: str = "localhost",
+        username: str = CONFIG.user,
+        timeout: int = CONFIG.command_timeout,
+    ) -> dict[str, Any]:
+        """Execute an Ansible module on a remote host.
+
+        Args:
+            module: Ansible module name (e.g., "setup", "command", "systemd")
+            module_args: Module arguments as dict or string
+            host: Target host address
+            username: SSH username
+            timeout: Execution timeout in seconds
+
+        Returns:
+            Module result as dictionary (structured Ansible output)
+
+        Raises:
+            AnsibleExecutionError: If Ansible execution fails or host unreachable
+            TimeoutError: If execution exceeds timeout
+
+        Example:
+            # Get systemd service facts
+            result = await executor.run_module(
+                module="service_facts",
+                host="server.example.com"
+            )
+            services = result["ansible_facts"]["services"]
+        """
+        loop = asyncio.get_running_loop()
+
+        logger.debug(f"ANSIBLE_EXEC: {module} | host={host} | args={module_args}")
+
+        try:
+            result = await asyncio.wait_for(
+                loop.run_in_executor(
+                    self._executor,
+                    self._run_ansible_module,
+                    module,
+                    module_args,
+                    host,
+                    username,
+                ),
+                timeout=timeout,
+            )
+
+            logger.debug(f"ANSIBLE_OK: {module} | host={host}")
+            return result
+
+        except asyncio.TimeoutError:
+            error_msg = f"Ansible module '{module}' timed out after {timeout}s on {host}"
+            logger.error(error_msg)
+            raise TimeoutError(error_msg) from None
+        except AnsibleExecutionError:
+            raise
+        except Exception as e:
+            logger.error(f"Ansible execution failed: {e}", extra={"ansible_module": module, "host": host})
+            raise AnsibleExecutionError(f"Failed to execute Ansible module '{module}' on {host}: {e}") from e
+
+    def _run_ansible_module(
+        self,
+        module: str,
+        module_args: dict[str, Any] | str | None,
+        host: str,
+        username: str,
+    ) -> dict[str, Any]:
+        """Synchronous Ansible execution (runs in thread pool).
+
+        This method runs in a separate thread to avoid blocking the async event loop.
+        It uses ansible-runner to execute a single module on a single host.
+
+        Args:
+            module: Ansible module name
+            module_args: Module arguments
+            host: Target host
+            username: SSH username
+
+        Returns:
+            Ansible module result dictionary
+
+        Raises:
+            AnsibleExecutionError: If execution fails or host unreachable
+        """
+        # Create temporary directory for ansible-runner artifacts
+        with tempfile.TemporaryDirectory(prefix="ansible-mcp-") as tmpdir:
+            # Harden permissions - Ansible writes sensitive data here
+            os.chmod(tmpdir, 0o700)
+
+            extravars = {
+                "ansible_user": username,
+                "ansible_host_key_checking": str(CONFIG.verify_host_keys).lower(),
+                # Enable SSH connection multiplexing for performance
+                "ansible_ssh_common_args": "-o ControlMaster=auto -o ControlPersist=60s",
+            }
+
+            # Add SSH key if available
+            if self._ssh_key:
+                extravars["ansible_ssh_private_key_file"] = self._ssh_key
+
+            # Convert dict args to string format for ansible-runner
+            args_str = self._format_module_args(module_args)
+
+            # Execute Ansible module
+            runner = ansible_runner.run(
+                private_data_dir=tmpdir,
+                host_pattern=host,
+                module=module,
+                module_args=args_str,
+                extravars=extravars,
+                quiet=True,
+                json_mode=True,
+            )
+
+            # Check execution status
+            # ansible_runner.run() returns Runner type, but pyright sees union types without proper stubs
+            if runner.status == "failed":
+                raise AnsibleExecutionError(
+                    f"Ansible execution failed on {host}: {runner.stats.get('failures', {})}"  # pyright: ignore[reportOptionalMemberAccess,reportAttributeAccessIssue]
+                )
+
+            if runner.status == "unreachable":
+                raise AnsibleExecutionError(f"Host unreachable: {host}")
+
+            # Extract module result from events
+            for event in runner.events:  # pyright: ignore[reportAttributeAccessIssue]
+                if event.get("event") == "runner_on_ok":
+                    return event["event_data"]["res"]
+
+            # No result found in events
+            raise AnsibleExecutionError(f"No result returned from Ansible module '{module}' on {host}")
+
+    def shutdown(self) -> None:
+        """Shutdown thread pool executor.
+
+        Safe to call multiple times - subsequent calls are no-ops.
+        Automatically registered with atexit for cleanup on interpreter exit.
+        """
+        if self._shutdown:
+            return
+        self._shutdown = True
+        logger.debug("Shutting down Ansible executor")
+        self._executor.shutdown(wait=True)
+
+
+# Global executor instance (lazy initialization)
+_ansible_executor: AnsibleExecutor | None = None
+
+
+def get_ansible_executor() -> AnsibleExecutor:
+    """Get or create the global Ansible executor instance."""
+    global _ansible_executor
+
+    if _ansible_executor is None:
+        _ansible_executor = AnsibleExecutor()
+
+    return _ansible_executor
+
+
+async def execute_ansible_module(
+    module: str,
+    module_args: dict[str, Any] | str | None = None,
+    host: str | None = None,
+    username: str = CONFIG.user,
+) -> dict[str, Any]:
+    """Execute an Ansible module (main entry point).
+
+    This is the primary interface for tools to execute Ansible modules. It manages
+    a singleton AnsibleExecutor instance and provides a simplified API.
+
+    Args:
+        module: Ansible module name
+        module_args: Module arguments
+        host: Optional remote host (None = localhost)
+        username: SSH username for remote connections
+
+    Returns:
+        Module result dictionary
+
+    Raises:
+        AnsibleExecutionError: If Ansible execution fails
+        TimeoutError: If execution times out
+
+    Example:
+        # Get block device information using setup module
+        result = await execute_ansible_module(
+            module="setup",
+            module_args={"gather_subset": ["!all", "!min", "devices"]},
+            host="server.example.com"
+        )
+        devices = result["ansible_facts"]["ansible_devices"]
+    """
+    executor = get_ansible_executor()
+
+    target_host = host or "localhost"
+    return await executor.run_module(
+        module=module,
+        module_args=module_args,
+        host=target_host,
+        username=username,
+    )

--- a/tests/connection/test_ansible.py
+++ b/tests/connection/test_ansible.py
@@ -1,0 +1,262 @@
+"""Tests for Ansible executor."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from linux_mcp_server.connection.ansible import AnsibleExecutionError
+from linux_mcp_server.connection.ansible import AnsibleExecutor
+from linux_mcp_server.connection.ansible import execute_ansible_module
+from linux_mcp_server.connection.ansible import get_ansible_executor
+
+
+@pytest.fixture
+def mock_ansible_runner():
+    """Mock ansible_runner.run() with successful execution."""
+    with patch("linux_mcp_server.connection.ansible.ansible_runner") as mock_runner_module:
+        # Create successful runner response
+        runner = MagicMock()
+        runner.status = "successful"
+        runner.stats = {"ok": {}, "failures": {}}
+        runner.events = [
+            {
+                "event": "runner_on_ok",
+                "event_data": {
+                    "res": {
+                        "ansible_facts": {
+                            "ansible_devices": {
+                                "sda": {
+                                    "model": "SAMSUNG SSD",
+                                    "size": "1.00 TB",
+                                    "vendor": "ATA",
+                                    "removable": "0",
+                                    "partitions": {
+                                        "sda1": {"size": "512.00 GB"},
+                                        "sda2": {"size": "488.00 GB"},
+                                    },
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+        ]
+        mock_runner_module.run.return_value = runner
+        yield mock_runner_module
+
+
+@pytest.fixture
+def reset_global_executor():
+    """Reset the global executor between tests."""
+    import linux_mcp_server.connection.ansible as ansible_module
+
+    original = ansible_module._ansible_executor
+    ansible_module._ansible_executor = None
+    yield
+    ansible_module._ansible_executor = original
+
+
+class TestAnsibleExecutor:
+    async def test_run_module_success(self, mock_ansible_runner):
+        """Test successful module execution."""
+        executor = AnsibleExecutor()
+
+        result = await executor.run_module(
+            module="setup",
+            module_args={"gather_subset": ["devices"]},
+            host="test.host.com",
+            username="testuser",
+        )
+
+        assert "ansible_facts" in result
+        assert "ansible_devices" in result["ansible_facts"]
+        assert "sda" in result["ansible_facts"]["ansible_devices"]
+
+        mock_ansible_runner.run.assert_called_once()
+        call_kwargs = mock_ansible_runner.run.call_args[1]
+        assert call_kwargs["module"] == "setup"
+        assert call_kwargs["host_pattern"] == "test.host.com"
+
+        executor.shutdown()
+
+    async def test_run_module_failed(self, mock_ansible_runner):
+        """Test module execution failure."""
+        mock_ansible_runner.run.return_value.status = "failed"
+        mock_ansible_runner.run.return_value.stats = {"failures": {"test.host.com": 1}}
+
+        executor = AnsibleExecutor()
+
+        with pytest.raises(AnsibleExecutionError, match="Ansible execution failed"):
+            await executor.run_module(
+                module="command",
+                module_args="false",
+                host="test.host.com",
+            )
+
+        executor.shutdown()
+
+    async def test_run_module_unreachable(self, mock_ansible_runner):
+        """Test unreachable host."""
+        mock_ansible_runner.run.return_value.status = "unreachable"
+
+        executor = AnsibleExecutor()
+
+        with pytest.raises(AnsibleExecutionError, match="Host unreachable"):
+            await executor.run_module(
+                module="ping",
+                host="unreachable.host.com",
+            )
+
+        executor.shutdown()
+
+    async def test_run_module_no_result(self, mock_ansible_runner):
+        """Test when no result is returned from events."""
+        mock_ansible_runner.run.return_value.status = "successful"
+        mock_ansible_runner.run.return_value.events = []
+
+        executor = AnsibleExecutor()
+
+        with pytest.raises(AnsibleExecutionError, match="No result returned"):
+            await executor.run_module(
+                module="setup",
+                host="test.host.com",
+            )
+
+        executor.shutdown()
+
+    async def test_run_module_timeout(self, mock_ansible_runner):
+        """Test execution timeout."""
+
+        def slow_run(*args, **kwargs):
+            import time
+
+            time.sleep(5)
+            return mock_ansible_runner.run.return_value
+
+        mock_ansible_runner.run.side_effect = slow_run
+
+        executor = AnsibleExecutor()
+
+        with pytest.raises(TimeoutError, match="timed out"):
+            await executor.run_module(
+                module="command",
+                module_args="sleep 100",
+                host="test.host.com",
+                timeout=1,
+            )
+
+        executor.shutdown()
+
+    async def test_run_module_with_ssh_key(self, mock_ansible_runner):
+        """Test module execution with SSH key."""
+        with patch("linux_mcp_server.connection.ansible.discover_ssh_key") as mock_discover:
+            mock_discover.return_value = "/home/user/.ssh/id_ed25519"
+            executor = AnsibleExecutor()
+
+            await executor.run_module(
+                module="setup",
+                host="test.host.com",
+            )
+
+            call_kwargs = mock_ansible_runner.run.call_args[1]
+            assert call_kwargs["extravars"]["ansible_ssh_private_key_file"] == "/home/user/.ssh/id_ed25519"
+
+            executor.shutdown()
+
+    async def test_run_module_localhost(self, mock_ansible_runner):
+        """Test module execution on localhost."""
+        executor = AnsibleExecutor()
+
+        result = await executor.run_module(
+            module="setup",
+            host="localhost",
+        )
+
+        assert "ansible_facts" in result
+        call_kwargs = mock_ansible_runner.run.call_args[1]
+        assert call_kwargs["host_pattern"] == "localhost"
+
+        executor.shutdown()
+
+
+class TestExecuteAnsibleModule:
+    async def test_execute_ansible_module_localhost(self, mock_ansible_runner, reset_global_executor):
+        """Test module execution on localhost via helper function."""
+        result = await execute_ansible_module(
+            module="setup",
+            module_args={"filter": "ansible_devices"},
+        )
+
+        assert "ansible_facts" in result
+        mock_ansible_runner.run.assert_called_once()
+        assert mock_ansible_runner.run.call_args[1]["host_pattern"] == "localhost"
+
+    async def test_execute_ansible_module_remote(self, mock_ansible_runner, reset_global_executor):
+        """Test module execution on remote host via helper function."""
+        result = await execute_ansible_module(
+            module="setup",
+            host="remote.host.com",
+            username="admin",
+        )
+
+        assert "ansible_facts" in result
+        call_kwargs = mock_ansible_runner.run.call_args[1]
+        assert call_kwargs["host_pattern"] == "remote.host.com"
+        assert call_kwargs["extravars"]["ansible_user"] == "admin"
+
+    async def test_get_ansible_executor_singleton(self, mock_ansible_runner, reset_global_executor):
+        """Test that get_ansible_executor returns the same instance."""
+        executor1 = get_ansible_executor()
+        executor2 = get_ansible_executor()
+
+        assert executor1 is executor2
+
+
+class TestAnsibleExecutorShutdown:
+    def test_shutdown_twice_is_noop(self, mock_ansible_runner):
+        """Test that shutdown() can be called multiple times safely."""
+        executor = AnsibleExecutor()
+
+        # First shutdown should work
+        executor.shutdown()
+        assert executor._shutdown is True
+
+        # Second shutdown should be a no-op (no exception)
+        executor.shutdown()
+        assert executor._shutdown is True
+
+    async def test_run_module_reraises_ansible_execution_error(self, mock_ansible_runner):
+        """Test that AnsibleExecutionError raised in _run_ansible_module is re-raised unchanged."""
+        executor = AnsibleExecutor()
+
+        # Simulate _run_ansible_module raising AnsibleExecutionError directly
+        def raise_ansible_error(*args, **kwargs):
+            raise AnsibleExecutionError("Original error message")
+
+        mock_ansible_runner.run.side_effect = raise_ansible_error
+
+        with pytest.raises(AnsibleExecutionError, match="Original error message"):
+            await executor.run_module(
+                module="test",
+                host="test.host.com",
+            )
+
+        executor.shutdown()
+
+    async def test_run_module_wraps_unexpected_exception(self, mock_ansible_runner):
+        """Test that unexpected exceptions are wrapped in AnsibleExecutionError."""
+        executor = AnsibleExecutor()
+
+        def raise_unexpected_error(*args, **kwargs):
+            raise RuntimeError("Unexpected error")
+
+        mock_ansible_runner.run.side_effect = raise_unexpected_error
+
+        with pytest.raises(AnsibleExecutionError, match="Failed to execute Ansible module"):
+            await executor.run_module(
+                module="test",
+                host="test.host.com",
+            )
+
+        executor.shutdown()

--- a/tests/tools/test_storage.py
+++ b/tests/tools/test_storage.py
@@ -1,12 +1,14 @@
 """Tests for storage tools."""
 
+import base64
+import json
 import os
 import sys
 
 from collections.abc import Callable
 from pathlib import Path
+from typing import Literal
 from unittest.mock import AsyncMock
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -16,1054 +18,558 @@ from linux_mcp_server.server import mcp
 from linux_mcp_server.tools.storage import NodeEntry
 
 
-@pytest.fixture
-def setup_test_directory(tmp_path) -> Callable[[list[tuple[str, int, float]]], tuple[Path, list[NodeEntry]]]:
-    """
-    Factory fixture for creating test directories with subdirectories of specific sizes and modification times.
+NodeType = Literal["directory", "file"]
 
-    Returns a function that accepts a list of (name, size, modified_time) tuples and:
-    - Creates subdirectories with the specified sizes (by adding a file within each)
+
+@pytest.fixture
+def setup_test_nodes(tmp_path) -> Callable[[list[tuple[str, int, float]], NodeType], tuple[Path, list[NodeEntry]]]:
+    """
+    Factory fixture for creating test directories or files with specific sizes and modification times.
+
+    Returns a function that accepts a list of (name, size, modified_time) tuples and a node_type, and:
+    - Creates directories or files with the specified sizes
     - Sets their modification times
     - Returns the directory path and list of expected NodeEntry objects
     """
 
-    def _create_directory(dir_specs: list[tuple[str, int, float]]) -> tuple[Path, list[NodeEntry]]:
-        """
-        Create a directory structure with specified subdirectories.
-
-        Args:
-            dir_specs: List of (name, size, modified_time) tuples
-
-        Returns:
-            Tuple of (directory_path, expected_entries)
-        """
+    def _create_nodes(
+        node_specs: list[tuple[str, int, float]],
+        node_type: NodeType = "directory",
+    ) -> tuple[Path, list[NodeEntry]]:
+        """Create directories or files with specified attributes."""
         expected_entries = []
 
-        for name, size, modified_time in dir_specs:
-            dir_path = tmp_path / name
-            dir_path.mkdir()
+        for name, size, modified_time in node_specs:
+            if node_type == "directory":
+                node_path = tmp_path / name
+                node_path.mkdir()
+                # Create a file inside the directory to give it size
+                if size > 0:
+                    content_file = node_path / "content.txt"
+                    content_file.write_text("x" * size)
+            else:
+                node_path = tmp_path / name
+                node_path.touch()
+                if size > 0:
+                    node_path.write_text("x" * size)
 
-            # Create a file inside the directory to give it size
-            if size > 0:
-                content_file = dir_path / "content.txt"
-                content_file.write_text("x" * size)
-
-            # Set modification time on the directory itself
-            os.utime(dir_path, (modified_time, modified_time))
-
+            os.utime(node_path, (modified_time, modified_time))
             expected_entries.append(NodeEntry(name=name, size=size, modified=modified_time))
 
         return tmp_path, expected_entries
 
-    return _create_directory
-
-
-@pytest.fixture
-def setup_test_files(tmp_path) -> Callable[[list[tuple[str, int, float]]], tuple[Path, list[NodeEntry]]]:
-    """
-    Factory fixture for creating test directories with subdirectories of specific sizes and modification times.
-
-    Returns a function that accepts a list of (name, size, modified_time) tuples and:
-    - Creates subdirectories with the specified sizes (by adding a file within each)
-    - Sets their modification times
-    - Returns the directory path and list of expected NodeEntry objects
-    """
-
-    def _create_files(dir_specs: list[tuple[str, int, float]]) -> tuple[Path, list[NodeEntry]]:
-        """
-        Create a directory structure with specified subdirectories.
-
-        Args:
-            dir_specs: List of (name, size, modified_time) tuples
-
-        Returns:
-            Tuple of (directory_path, expected_entries)
-        """
-        expected_entries = []
-
-        for name, size, modified_time in dir_specs:
-            content_file = tmp_path / name
-            content_file.touch()
-
-            # Create a file inside the directory to give it size
-            if size > 0:
-                content_file.write_text("x" * size)
-
-            # Set modification time on the file itself
-            os.utime(content_file, (modified_time, modified_time))
-
-            expected_entries.append(NodeEntry(name=name, size=size, modified=modified_time))
-
-        return tmp_path, expected_entries
-
-    return _create_files
+    return _create_nodes
 
 
 @pytest.fixture
 def restricted_path(tmp_path):
-    restricted_path = tmp_path / "restricted"
-    restricted_path.mkdir()
-    restricted_path.chmod(0o000)
+    restricted = tmp_path / "restricted"
+    restricted.mkdir()
+    restricted.chmod(0o000)
 
-    yield restricted_path
+    yield restricted
 
-    restricted_path.chmod(0o755)
+    restricted.chmod(0o755)
+
+
+def parse_node_result(result) -> list[NodeEntry]:
+    """Parse tool result into list of NodeEntry objects."""
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert isinstance(result[1], dict)
+    return [NodeEntry(**entry) for entry in result[1]["result"]]
 
 
 class TestListBlockDevices:
-    async def test_list_block_devices_lsblk_success(self, mocker):
-        """Test list_block_devices with successful lsblk command."""
-        mock_execute_command = AsyncMock(
-            return_value=(
-                0,
-                "NAME   SIZE TYPE MOUNTPOINT FSTYPE MODEL\nsda    1TB  disk            \nsda1   512G part /          ext4",
-                "",
-            )
-        )
-        mocker.patch("linux_mcp_server.tools.storage.execute_command", mock_execute_command)
-
-        result = await mcp.call_tool("list_block_devices", {})
-
-        # Verify result structure
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[0], list)
-        output = result[0][0].text
-
-        assert "=== Block Devices ===" in output
-        assert "sda" in output
-        assert "sda1" in output
-
-        # Verify lsblk was called with correct arguments
-        mock_execute_command.assert_called_once()
-        args = mock_execute_command.call_args[0][0]
-        assert args[0] == "lsblk"
-        assert "-o" in args
-
-    async def test_list_block_devices_with_disk_io_stats(self, mocker):
-        """Test list_block_devices includes disk I/O statistics for local execution."""
-        mocker.patch(
-            "linux_mcp_server.tools.storage.execute_command",
-            AsyncMock(
-                return_value=(
-                    0,
-                    "NAME   SIZE TYPE MOUNTPOINT\nsda    1TB  disk",
-                    "",
-                )
+    @pytest.mark.parametrize(
+        ("devices", "host"),
+        [
+            pytest.param(
+                {
+                    "sda": {"model": "SAMSUNG SSD", "size": "1.00 TB", "partitions": {"sda1": {"size": "512.00 GB"}}},
+                    "nvme0n1": {"model": "Samsung NVMe", "size": "500.00 GB", "partitions": {}},
+                },
+                None,
+                id="multiple_devices_local",
             ),
-        )
+            pytest.param({}, None, id="no_devices"),
+            pytest.param(
+                {"vda": {"model": "Virtio", "size": "20.00 GB", "partitions": {}}},
+                "remote.server.com",
+                id="remote_host",
+            ),
+        ],
+    )
+    async def test_list_block_devices(self, mocker, devices, host):
+        """Test list_block_devices returns JSON device info."""
+        mock_execute_ansible = AsyncMock(return_value={"ansible_facts": {"ansible_devices": devices}})
+        mocker.patch("linux_mcp_server.tools.storage.execute_ansible_module", mock_execute_ansible)
 
-        # Create mock disk I/O stats
-        mock_stats = MagicMock()
-        mock_stats.read_bytes = 1024 * 1024 * 1024  # 1 GB
-        mock_stats.write_bytes = 512 * 1024 * 1024  # 512 MB
-        mock_stats.read_count = 1000
-        mock_stats.write_count = 500
+        params = {"host": host} if host else {}
+        result = await mcp.call_tool("list_block_devices", params)
 
-        mocker.patch("linux_mcp_server.tools.storage.psutil.disk_io_counters", return_value={"sda": mock_stats})
-
-        result = await mcp.call_tool("list_block_devices", {})
         assert isinstance(result, tuple)
-        assert len(result) == 2
         assert isinstance(result[0], list)
-        output = result[0][0].text
+        output = json.loads(result[0][0].text)  # pyright: ignore[reportIndexIssue]
+        assert output == devices
 
-        assert "=== Disk I/O Statistics (per disk) ===" in output
-        assert "sda:" in output
-        assert "Read:" in output
-        assert "Write:" in output
-        assert "Read Count: 1000" in output
-        assert "Write Count: 500" in output
+        call_kwargs = mock_execute_ansible.call_args[1]
+        assert call_kwargs["module"] == "setup"
+        assert call_kwargs["host"] == host
 
-    async def test_list_block_devices_with_no_disk_io_stats(self, mocker):
-        """Test list_block_devices includes disk I/O statistics for local execution."""
-        mocker.patch("linux_mcp_server.tools.storage.execute_command", return_value=(0, "", ""))
-        mocker.patch("linux_mcp_server.tools.storage.psutil.disk_io_counters", return_value={})
 
-        result = await mcp.call_tool("list_block_devices", {})
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[0], list)
-        output = result[0][0].text
+# Common test data for directories and files
+ALPHA_BETA_GAMMA_SPECS = [
+    ("alpha", 100, 1000.0),
+    ("beta", 200, 2000.0),
+    ("gamma", 300, 3000.0),
+]
 
-        assert "=== Disk I/O Statistics (per disk) ===" not in output
+SIZE_ORDERED_SPECS = [
+    ("small", 100, 1000.0),
+    ("large", 300, 3000.0),
+    ("medium", 200, 2000.0),
+]
 
-    async def test_list_block_devices_lsblk_fallback(self, mocker):
-        """Test list_block_devices falls back to psutil when lsblk fails."""
-        # lsblk returns non-zero
-        mocker.patch(
-            "linux_mcp_server.tools.storage.execute_command", AsyncMock(return_value=(1, "", "command failed"))
-        )
-
-        # Mock partition data
-        mock_partition = MagicMock()
-        mock_partition.device = "/dev/sda1"
-        mock_partition.mountpoint = "/"
-        mock_partition.fstype = "ext4"
-        mock_partition.opts = "rw,relatime"
-
-        mocker.patch("linux_mcp_server.tools.storage.psutil.disk_partitions", return_value=[mock_partition])
-
-        result = await mcp.call_tool("list_block_devices", {})
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[0], list)
-        output = result[0][0].text
-
-        assert "=== Block Devices (fallback) ===" in output
-        assert "/dev/sda1" in output
-        assert "Mountpoint: /" in output
-        assert "Filesystem: ext4" in output
-
-    async def test_list_block_devices_file_not_found(self, mocker):
-        """Test list_block_devices when lsblk is not available."""
-        # lsblk not found
-        mocker.patch("linux_mcp_server.tools.storage.execute_command", side_effect=FileNotFoundError("lsblk not found"))
-
-        # Mock partition data
-        mock_partition = MagicMock()
-        mock_partition.device = "/dev/nvme0n1p1"
-        mock_partition.mountpoint = "/boot"
-        mock_partition.fstype = "vfat"
-        mock_partition.opts = "rw"
-
-        mocker.patch("linux_mcp_server.tools.storage.psutil.disk_partitions", return_value=[mock_partition])
-
-        result = await mcp.call_tool("list_block_devices", {})
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[0], list)
-        output = result[0][0].text
-
-        assert "=== Block Devices ===" in output
-        assert "/dev/nvme0n1p1" in output
-        assert "Mountpoint: /boot" in output
-
-    async def test_list_block_devices_remote_execution(self, mocker):
-        """Test list_block_devices with remote execution (no disk I/O stats)."""
-        mock_execute_command = AsyncMock(
-            return_value=(
-                0,
-                "NAME   SIZE TYPE\nsda    1TB  disk",
-                "",
-            )
-        )
-        mocker.patch("linux_mcp_server.tools.storage.execute_command", mock_execute_command)
-
-        # Mock disk I/O to ensure it's not called or used
-        mock_stats = MagicMock()
-        mock_stats.read_bytes = 1024
-        mocker.patch("linux_mcp_server.tools.storage.psutil.disk_io_counters", return_value={"sda": mock_stats})
-
-        result = await mcp.call_tool("list_block_devices", {"host": "remote.host.com"})
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[0], list)
-        output = result[0][0].text
-
-        # Should NOT include disk I/O stats for remote execution
-        assert "=== Disk I/O Statistics" not in output
-        assert "=== Block Devices ===" in output
-
-        # Verify execute_command was called with host
-        mock_execute_command.assert_called_once()
-        call_kwargs = mock_execute_command.call_args[1]
-        assert call_kwargs["host"] == "remote.host.com"
-
-    async def test_list_block_devices_exception_handling(self, mocker):
-        """Test list_block_devices handles general exceptions."""
-        mocker.patch("linux_mcp_server.tools.storage.execute_command", side_effect=ValueError("Raised intentionally"))
-
-        with pytest.raises(ToolError, match="Raised intentionally"):
-            await mcp.call_tool("list_block_devices", {})
+TIME_ORDERED_SPECS = [
+    ("newest", 100, 3000.0),
+    ("oldest", 100, 1000.0),
+    ("middle", 100, 2000.0),
+]
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="requires GNU version of coreutils/findutils")
 class TestListDirectories:
-    async def test_list_directories_returns_structured_output(self, setup_test_directory):
+    async def test_list_directories_returns_structured_output(self, setup_test_nodes):
         """Test that list_directories returns structured output."""
-        file_specs = [
-            ("alpha", 100, 1000.0),
-            ("beta", 200, 2000.0),
-            ("gamma", 300, 3000.0),
-        ]
-        test_path, _ = setup_test_directory(file_specs)
+        test_path, _ = setup_test_nodes(ALPHA_BETA_GAMMA_SPECS, "directory")
 
         result = await mcp.call_tool("list_directories", {"path": str(test_path), "order_by": "name"})
 
-        # Verify the entire result structure
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        directories = list[NodeEntry](result[1]["result"])
-        assert directories is not None
+        got = parse_node_result(result)
+        assert got is not None
 
-    async def test_list_directories_by_name(self, setup_test_directory):
-        """Test that list_directories returns structured output sorted by name."""
-        dir_specs = [
-            ("alpha", 100, 1000.0),
-            ("beta", 200, 2000.0),
-            ("gamma", 300, 3000.0),
-        ]
-        test_path, _ = setup_test_directory(dir_specs)
+    @pytest.mark.parametrize(
+        ("order_by", "sort", "specs", "expected"),
+        [
+            pytest.param(
+                "name",
+                "ascending",
+                ALPHA_BETA_GAMMA_SPECS,
+                [
+                    NodeEntry(name="alpha", size=0, modified=0.0),
+                    NodeEntry(name="beta", size=0, modified=0.0),
+                    NodeEntry(name="gamma", size=0, modified=0.0),
+                ],
+                id="name_ascending",
+            ),
+            pytest.param(
+                "name",
+                "descending",
+                ALPHA_BETA_GAMMA_SPECS,
+                [
+                    NodeEntry(name="gamma", size=0, modified=0.0),
+                    NodeEntry(name="beta", size=0, modified=0.0),
+                    NodeEntry(name="alpha", size=0, modified=0.0),
+                ],
+                id="name_descending",
+            ),
+            pytest.param(
+                "modified",
+                "ascending",
+                TIME_ORDERED_SPECS,
+                [
+                    NodeEntry(name="oldest", size=0, modified=1000.0),
+                    NodeEntry(name="middle", size=0, modified=2000.0),
+                    NodeEntry(name="newest", size=0, modified=3000.0),
+                ],
+                id="modified_ascending",
+            ),
+            pytest.param(
+                "modified",
+                "descending",
+                TIME_ORDERED_SPECS,
+                [
+                    NodeEntry(name="newest", size=0, modified=3000.0),
+                    NodeEntry(name="middle", size=0, modified=2000.0),
+                    NodeEntry(name="oldest", size=0, modified=1000.0),
+                ],
+                id="modified_descending",
+            ),
+        ],
+    )
+    async def test_list_directories_ordering(self, setup_test_nodes, order_by, sort, specs, expected):
+        """Test list_directories with various orderings and sort directions."""
+        test_path, _ = setup_test_nodes(specs, "directory")
 
-        # When ordering by name, only the name field is populated
-        expected_entries = [
-            NodeEntry(name="alpha", size=0, modified=0.0),
-            NodeEntry(name="beta", size=0, modified=0.0),
-            NodeEntry(name="gamma", size=0, modified=0.0),
-        ]
+        result = await mcp.call_tool("list_directories", {"path": str(test_path), "order_by": order_by, "sort": sort})
 
-        result = await mcp.call_tool("list_directories", {"path": str(test_path), "order_by": "name"})
+        got = parse_node_result(result)
+        assert got == expected
 
-        # Verify the structured output
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
+    @pytest.mark.parametrize("sort", ["ascending", "descending"])
+    async def test_list_directories_by_size(self, setup_test_nodes, sort):
+        """Test list_directories sorted by size returns all directories.
 
-    async def test_list_directories_by_size(self, setup_test_directory):
-        """Test that list_directories returns structured output sorted by size."""
-        dir_specs = [
-            ("small", 100, 1000.0),
-            ("large", 300, 3000.0),
-            ("medium", 200, 2000.0),
-        ]
-        test_path, _ = setup_test_directory(dir_specs)
+        Note: Ansible's find module returns directory inode size, not contents size.
+        All directories have similar inode sizes, so we just verify all are returned.
+        """
+        test_path, _ = setup_test_nodes(SIZE_ORDERED_SPECS, "directory")
 
-        expected_entries = [
-            NodeEntry(name="small", size=100, modified=0.0),
-            NodeEntry(name="medium", size=200, modified=0.0),
-            NodeEntry(name="large", size=300, modified=0.0),
-        ]
+        result = await mcp.call_tool("list_directories", {"path": str(test_path), "order_by": "size", "sort": sort})
 
-        result = await mcp.call_tool(
-            "list_directories", {"path": str(test_path), "order_by": "size", "sort": "ascending"}
-        )
+        got = parse_node_result(result)
+        names = {entry.name for entry in got}
+        assert names == {"small", "medium", "large"}
 
-        # Verify the structured output - should be sorted by size (ascending)
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
-
-    async def test_list_directories_by_modified(self, setup_test_directory):
-        """Test that list_directories returns structured output sorted by modification time."""
-        dir_specs = [
-            ("newest", 0, 3000.0),
-            ("oldest", 100, 1000.0),
-            ("middle", 100, 2000.0),
-        ]
-        test_path, _ = setup_test_directory(dir_specs)
-
-        # When ordering by modified, only name and modified fields are populated
-        expected_entries = [
-            NodeEntry(name="oldest", size=0, modified=1000.0),
-            NodeEntry(name="middle", size=0, modified=2000.0),
-            NodeEntry(name="newest", size=0, modified=3000.0),
-        ]
-
-        result = await mcp.call_tool(
-            "list_directories", {"path": str(test_path), "order_by": "modified", "sort": "ascending"}
-        )
-
-        # Verify the structured output - should be sorted by modification time (ascending)
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
-
-    async def test_list_directories_by_name_with_top_n(self, setup_test_directory):
-        """Test that list_directories returns structured output sorted by name with top_n limit."""
-        dir_specs = [
-            ("alpha", 100, 1000.0),
-            ("beta", 200, 2000.0),
-            ("gamma", 300, 3000.0),
-        ]
-        test_path, _ = setup_test_directory(dir_specs)
-
-        # When ordering by name, only name field is populated
-        expected_entries = [
-            NodeEntry(name="alpha", size=0, modified=0.0),
-            NodeEntry(name="beta", size=0, modified=0.0),
-        ]
-
-        result = await mcp.call_tool("list_directories", {"path": str(test_path), "order_by": "name", "top_n": 2})
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
-
-    async def test_list_directories_by_name_descending(self, setup_test_directory):
-        """Test that list_directories returns structured output sorted by name in descending order."""
-        dir_specs = [
-            ("alpha", 100, 1000.0),
-            ("beta", 200, 2000.0),
-            ("gamma", 300, 3000.0),
-        ]
-        test_path, _ = setup_test_directory(dir_specs)
-
-        expected_entries = [
-            NodeEntry(name="gamma", size=0, modified=0.0),
-            NodeEntry(name="beta", size=0, modified=0.0),
-            NodeEntry(name="alpha", size=0, modified=0.0),
-        ]
+    @pytest.mark.parametrize(
+        ("order_by", "specs", "top_n", "expected_names"),
+        [
+            pytest.param("name", ALPHA_BETA_GAMMA_SPECS, 2, ["alpha", "beta"], id="name_top_2"),
+            pytest.param(
+                "modified",
+                TIME_ORDERED_SPECS,
+                2,
+                ["oldest", "middle"],
+                id="modified_top_2",
+            ),
+        ],
+    )
+    async def test_list_directories_with_top_n(self, setup_test_nodes, order_by, specs, top_n, expected_names):
+        """Test list_directories with top_n limit."""
+        test_path, _ = setup_test_nodes(specs, "directory")
 
         result = await mcp.call_tool(
-            "list_directories", {"path": str(test_path), "order_by": "name", "sort": "descending"}
+            "list_directories", {"path": str(test_path), "order_by": order_by, "sort": "ascending", "top_n": top_n}
         )
 
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
+        got = parse_node_result(result)
+        assert [entry.name for entry in got] == expected_names
 
-    async def test_list_directories_by_size_descending(self, setup_test_directory):
-        """Test that list_directories returns structured output sorted by size in descending order."""
-        dir_specs = [
-            ("small", 100, 1000.0),
-            ("large", 300, 3000.0),
-            ("medium", 200, 2000.0),
-        ]
-        test_path, _ = setup_test_directory(dir_specs)
-
-        expected_entries = [
-            NodeEntry(name="large", size=300, modified=0.0),
-            NodeEntry(name="medium", size=200, modified=0.0),
-            NodeEntry(name="small", size=100, modified=0.0),
-        ]
-
-        result = await mcp.call_tool(
-            "list_directories", {"path": str(test_path), "order_by": "size", "sort": "descending"}
-        )
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
-
-    async def test_list_directories_by_modified_descending(self, setup_test_directory):
-        """Test that list_directories returns structured output sorted by modified time in descending order."""
-        dir_specs = [
-            ("newest", 100, 3000.0),
-            ("oldest", 100, 1000.0),
-            ("middle", 100, 2000.0),
-        ]
-        test_path, _ = setup_test_directory(dir_specs)
-
-        expected_entries = [
-            NodeEntry(name="newest", size=0, modified=3000.0),
-            NodeEntry(name="middle", size=0, modified=2000.0),
-            NodeEntry(name="oldest", size=0, modified=1000.0),
-        ]
-
-        result = await mcp.call_tool(
-            "list_directories", {"path": str(test_path), "order_by": "modified", "sort": "descending"}
-        )
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
-
-    async def test_list_directories_invalid_order_by(self, tmp_path):
-        """Test that invalid order_by parameter raises ValueError."""
-        with pytest.raises(ToolError, match="1 validation error"):
-            await mcp.call_tool("list_directories", {"path": str(tmp_path), "order_by": "invalid"})
-
-    async def test_list_directories_invalid_sort(self, tmp_path):
-        """Test that invalid sort parameter raises ValueError."""
-        with pytest.raises(ToolError, match="1 validation error"):
-            await mcp.call_tool("list_directories", {"path": str(tmp_path), "sort": "invalid"})
-
-    async def test_list_directories_invalid_path(self, tmp_path):
-        """Test with non-existent path raises ToolError."""
-        non_existent_path = tmp_path / "non_existent_directory"
-        with pytest.raises(ToolError, match="Path does not exist or cannot be resolved"):
-            await mcp.call_tool("list_directories", {"path": str(non_existent_path), "order_by": "name"})
-
-    async def test_list_directories_handles_permission_denied(self, restricted_path):
-        """Test handling of permission denied errors gracefully."""
-        with pytest.raises(ToolError, match="Permission denied to read"):
-            await mcp.call_tool("list_directories", {"path": str(restricted_path)})
-
-    async def test_list_directories_empty_directory_by_name(self, tmp_path):
-        """Test list_directories with a directory containing no subdirectories (name ordering)."""
-        result = await mcp.call_tool("list_directories", {"path": str(tmp_path), "order_by": "name"})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == []
-
-    async def test_list_directories_empty_directory_by_size(self, tmp_path):
-        """Test list_directories with a directory containing no subdirectories (size ordering)."""
-        result = await mcp.call_tool("list_directories", {"path": str(tmp_path), "order_by": "size"})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == []
-
-    async def test_list_directories_empty_directory_by_modified(self, tmp_path):
-        """Test list_directories with a directory containing no subdirectories (modified ordering)."""
-        result = await mcp.call_tool("list_directories", {"path": str(tmp_path), "order_by": "modified"})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == []
-
-    async def test_list_directories_special_characters_in_names(self, tmp_path):
-        """Test list_directories handles directory names with special characters."""
-        # Create directories with special characters
-        (tmp_path / "dir with spaces").mkdir()
-        (tmp_path / "dir-with-dashes").mkdir()
-        (tmp_path / "dir_with_underscores").mkdir()
-
-        result = await mcp.call_tool("list_directories", {"path": str(tmp_path), "order_by": "name"})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-
-        # Verify all directory names are correctly parsed
-        names = [entry.name for entry in got]
-        assert "dir with spaces" in names
-        assert "dir-with-dashes" in names
-        assert "dir_with_underscores" in names
-        assert len(got) == 3
-
-    async def test_list_directories_by_modified_with_top_n(self, setup_test_directory):
-        """Test that list_directories returns structured output sorted by modified time with top_n limit."""
-        dir_specs = [
-            ("newest", 100, 3000.0),
-            ("oldest", 100, 1000.0),
-            ("middle", 100, 2000.0),
-        ]
-        test_path, _ = setup_test_directory(dir_specs)
-
-        expected_entries = [
-            NodeEntry(name="oldest", size=0, modified=1000.0),
-            NodeEntry(name="middle", size=0, modified=2000.0),
-        ]
-
-        result = await mcp.call_tool(
-            "list_directories", {"path": str(test_path), "order_by": "modified", "sort": "ascending", "top_n": 2}
-        )
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
-
-    async def test_list_directories_by_size_with_top_n_descending(self, setup_test_directory):
-        """Test that list_directories returns structured output sorted by size with top_n limit and descending order."""
-        dir_specs = [
-            ("small", 100, 1000.0),
-            ("large", 300, 3000.0),
-            ("medium", 200, 2000.0),
-            ("tiny", 50, 500.0),
-        ]
-        test_path, _ = setup_test_directory(dir_specs)
-
-        expected_entries = [
-            NodeEntry(name="large", size=300, modified=0.0),
-            NodeEntry(name="medium", size=200, modified=0.0),
-        ]
+    async def test_list_directories_by_size_with_top_n_descending(self, setup_test_nodes):
+        """Test list_directories with size ordering, top_n limit, and descending order."""
+        specs = [("small", 100, 1000.0), ("large", 300, 3000.0), ("medium", 200, 2000.0), ("tiny", 50, 500.0)]
+        test_path, _ = setup_test_nodes(specs, "directory")
 
         result = await mcp.call_tool(
             "list_directories", {"path": str(test_path), "order_by": "size", "sort": "descending", "top_n": 2}
         )
 
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
+        got = parse_node_result(result)
+        assert len(got) == 2
 
-    async def test_list_directories_remote_execution_by_size(self, mocker):
-        """Test list_directories with remote execution for size ordering."""
-        # Mock du command output
-        mock_execute_command = AsyncMock(
-            return_value=(
-                0,
-                "100\t/remote/path/small\n300\t/remote/path/large\n200\t/remote/path/medium\n500\t/remote/path",
-                "",
-            )
+    @pytest.mark.parametrize("order_by", ["name", "size", "modified"])
+    async def test_list_directories_empty_directory(self, tmp_path, order_by):
+        """Test list_directories with a directory containing no subdirectories."""
+        result = await mcp.call_tool("list_directories", {"path": str(tmp_path), "order_by": order_by})
+
+        got = parse_node_result(result)
+        assert got == []
+
+    @pytest.mark.parametrize(
+        ("param", "value", "error_match"),
+        [
+            pytest.param("order_by", "invalid", "1 validation error", id="invalid_order_by"),
+            pytest.param("sort", "invalid", "1 validation error", id="invalid_sort"),
+        ],
+    )
+    async def test_list_directories_invalid_params(self, tmp_path, param, value, error_match):
+        """Test that invalid parameters raise ValueError."""
+        params = {"path": str(tmp_path), param: value}
+        with pytest.raises(ToolError, match=error_match):
+            await mcp.call_tool("list_directories", params)
+
+    async def test_list_directories_invalid_path(self, tmp_path):
+        """Test with non-existent path returns empty results via Ansible."""
+        non_existent_path = tmp_path / "non_existent_directory"
+        result = await mcp.call_tool("list_directories", {"path": str(non_existent_path), "order_by": "name"})
+
+        got = parse_node_result(result)
+        assert got == []
+
+    async def test_list_directories_handles_permission_denied(self, restricted_path):
+        """Test handling of permission denied returns empty results via Ansible."""
+        result = await mcp.call_tool("list_directories", {"path": str(restricted_path)})
+
+        got = parse_node_result(result)
+        assert got == []
+
+    async def test_list_directories_special_characters_in_names(self, tmp_path):
+        """Test list_directories handles directory names with special characters."""
+        special_names = ["dir with spaces", "dir-with-dashes", "dir_with_underscores"]
+        for name in special_names:
+            (tmp_path / name).mkdir()
+
+        result = await mcp.call_tool("list_directories", {"path": str(tmp_path), "order_by": "name"})
+
+        got = parse_node_result(result)
+        names = [entry.name for entry in got]
+        for expected in special_names:
+            assert expected in names
+        assert len(got) == 3
+
+    @pytest.mark.parametrize(
+        ("order_by", "files", "expected"),
+        [
+            pytest.param(
+                "size",
+                [
+                    {"path": "/remote/path/small", "size": 100, "mtime": 1000.0},
+                    {"path": "/remote/path/large", "size": 300, "mtime": 3000.0},
+                    {"path": "/remote/path/medium", "size": 200, "mtime": 2000.0},
+                ],
+                [
+                    NodeEntry(name="small", size=100, modified=0.0),
+                    NodeEntry(name="medium", size=200, modified=0.0),
+                    NodeEntry(name="large", size=300, modified=0.0),
+                ],
+                id="size_ordering",
+            ),
+            pytest.param(
+                "name",
+                [
+                    {"path": "/remote/path/gamma", "size": 300, "mtime": 3000.0},
+                    {"path": "/remote/path/alpha", "size": 100, "mtime": 1000.0},
+                    {"path": "/remote/path/beta", "size": 200, "mtime": 2000.0},
+                ],
+                [
+                    NodeEntry(name="alpha", size=0, modified=0.0),
+                    NodeEntry(name="beta", size=0, modified=0.0),
+                    NodeEntry(name="gamma", size=0, modified=0.0),
+                ],
+                id="name_ordering",
+            ),
+            pytest.param(
+                "modified",
+                [
+                    {"path": "/remote/path/newest", "size": 100, "mtime": 3000.0},
+                    {"path": "/remote/path/oldest", "size": 100, "mtime": 1000.0},
+                    {"path": "/remote/path/middle", "size": 100, "mtime": 2000.0},
+                ],
+                [
+                    NodeEntry(name="oldest", size=0, modified=1000.0),
+                    NodeEntry(name="middle", size=0, modified=2000.0),
+                    NodeEntry(name="newest", size=0, modified=3000.0),
+                ],
+                id="modified_ordering",
+            ),
+        ],
+    )
+    async def test_list_directories_ansible_execution(self, mocker, order_by, files, expected):
+        """Test list_directories with Ansible execution for various orderings."""
+        mock_ansible = AsyncMock(return_value={"files": files})
+        mocker.patch("linux_mcp_server.tools.storage.execute_ansible_module", mock_ansible)
+
+        result = await mcp.call_tool(
+            "list_directories",
+            {"path": "/remote/path", "order_by": order_by, "host": "remote.server.com"},
         )
-        mocker.patch("linux_mcp_server.tools.storage.execute_command", mock_execute_command)
 
+        got = parse_node_result(result)
+        assert got == expected
+
+        call_kwargs = mock_ansible.call_args[1]
+        assert call_kwargs["module"] == "find"
+        assert call_kwargs["module_args"]["file_type"] == "directory"
+        assert call_kwargs["host"] == "remote.server.com"
+
+    async def test_list_directories_ansible_descending(self, mocker):
+        """Test list_directories with Ansible and descending sort."""
+        files = [
+            {"path": "/remote/path/small", "size": 100, "mtime": 1000.0},
+            {"path": "/remote/path/large", "size": 300, "mtime": 3000.0},
+            {"path": "/remote/path/medium", "size": 200, "mtime": 2000.0},
+        ]
+        mock_ansible = AsyncMock(return_value={"files": files})
+        mocker.patch("linux_mcp_server.tools.storage.execute_ansible_module", mock_ansible)
+
+        result = await mcp.call_tool(
+            "list_directories",
+            {"path": "/remote/path", "order_by": "size", "sort": "descending", "host": "remote.server.com"},
+        )
+
+        got = parse_node_result(result)
+        assert [e.name for e in got] == ["large", "medium", "small"]
+        assert got[0].size == 300
+
+    async def test_list_directories_ansible_with_top_n(self, mocker):
+        """Test list_directories with Ansible and top_n limit."""
+        files = [
+            {"path": "/remote/path/small", "size": 100, "mtime": 1000.0},
+            {"path": "/remote/path/large", "size": 300, "mtime": 3000.0},
+            {"path": "/remote/path/medium", "size": 200, "mtime": 2000.0},
+        ]
+        mock_ansible = AsyncMock(return_value={"files": files})
+        mocker.patch("linux_mcp_server.tools.storage.execute_ansible_module", mock_ansible)
+
+        result = await mcp.call_tool(
+            "list_directories",
+            {"path": "/remote/path", "order_by": "size", "top_n": 2, "host": "remote.server.com"},
+        )
+
+        got = parse_node_result(result)
+        assert len(got) == 2
+        assert [e.name for e in got] == ["small", "medium"]
+
+    async def test_list_directories_ansible_empty_results(self, mocker):
+        """Test list_directories with Ansible returns empty list for no matches."""
+        mock_ansible = AsyncMock(return_value={"files": []})
+        mocker.patch("linux_mcp_server.tools.storage.execute_ansible_module", mock_ansible)
+
+        result = await mcp.call_tool(
+            "list_directories",
+            {"path": "/remote/empty", "order_by": "name", "host": "remote.server.com"},
+        )
+
+        got = parse_node_result(result)
+        assert got == []
+
+    async def test_list_directories_ansible_missing_optional_fields(self, mocker):
+        """Test list_directories handles missing optional fields from Ansible."""
+        # Ansible find may return entries without size or mtime
+        files = [
+            {"path": "/remote/path/no_size"},  # Missing size and mtime
+            {"path": "/remote/path/no_mtime", "size": 100},  # Missing mtime
+        ]
+        mock_ansible = AsyncMock(return_value={"files": files})
+        mocker.patch("linux_mcp_server.tools.storage.execute_ansible_module", mock_ansible)
+
+        # Test size ordering with missing size
         result = await mcp.call_tool(
             "list_directories",
             {"path": "/remote/path", "order_by": "size", "host": "remote.server.com"},
         )
+        got = parse_node_result(result)
+        assert len(got) == 2
+        assert got[0].size == 0  # Default value
+        assert got[1].size == 100
 
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-
-        # Verify results are sorted by size
-        assert len(got) == 3
-        assert got[0].name == "small"
-        assert got[0].size == 100
-        assert got[1].name == "medium"
-        assert got[1].size == 200
-        assert got[2].name == "large"
-        assert got[2].size == 300
-
-        # Verify execute_command was called with host
-        mock_execute_command.assert_called_once()
-        call_kwargs = mock_execute_command.call_args[1]
-        assert call_kwargs["host"] == "remote.server.com"
-
-    async def test_list_directories_remote_execution_by_name(self, mocker):
-        """Test list_directories with remote execution for name ordering."""
-        # Mock find command output
-        mock_execute_command = AsyncMock(
-            return_value=(
-                0,
-                "gamma\nalpha\nbeta",
-                "",
-            )
-        )
-        mocker.patch("linux_mcp_server.tools.storage.execute_command", mock_execute_command)
-
-        result = await mcp.call_tool(
-            "list_directories",
-            {"path": "/remote/path", "order_by": "name", "host": "remote.server.com"},
-        )
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-
-        # Verify results are sorted by name
-        assert len(got) == 3
-        assert got[0].name == "alpha"
-        assert got[1].name == "beta"
-        assert got[2].name == "gamma"
-
-        # Verify execute_command was called with host
-        mock_execute_command.assert_called_once()
-        call_kwargs = mock_execute_command.call_args[1]
-        assert call_kwargs["host"] == "remote.server.com"
-
-    async def test_list_directories_remote_execution_by_modified(self, mocker):
-        """Test list_directories with remote execution for modified ordering."""
-        # Mock find command output with timestamps
-        mock_execute_command = AsyncMock(
-            return_value=(
-                0,
-                "3000.0\tnewest\n1000.0\toldest\n2000.0\tmiddle",
-                "",
-            )
-        )
-        mocker.patch("linux_mcp_server.tools.storage.execute_command", mock_execute_command)
-
+        # Test modified ordering with missing mtime
         result = await mcp.call_tool(
             "list_directories",
             {"path": "/remote/path", "order_by": "modified", "host": "remote.server.com"},
         )
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-
-        # Verify results are sorted by modified time
-        assert len(got) == 3
-        assert got[0].name == "oldest"
-        assert got[0].modified == 1000.0
-        assert got[1].name == "middle"
-        assert got[1].modified == 2000.0
-        assert got[2].name == "newest"
-        assert got[2].modified == 3000.0
-
-        # Verify execute_command was called with host
-        mock_execute_command.assert_called_once()
-        call_kwargs = mock_execute_command.call_args[1]
-        assert call_kwargs["host"] == "remote.server.com"
-
-    async def test_list_directories_remote_skips_path_validation(self, mocker):
-        """Test that remote execution skips local path validation."""
-        # Mock du command output
-        mocker.patch(
-            "linux_mcp_server.tools.storage.execute_command",
-            AsyncMock(
-                return_value=(
-                    0,
-                    "100\t/nonexistent/path",
-                    "",
-                )
-            ),
-        )
-
-        # This path doesn't exist locally but should not raise an error for remote execution
-        result = await mcp.call_tool(
-            "list_directories",
-            {"path": "/nonexistent/remote/path", "order_by": "size", "host": "remote.server.com"},
-        )
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        # Should succeed even though path doesn't exist locally
-        assert isinstance(result[1], dict)
-
-    async def test_list_directories_du_command_failure(self, mocker):
-        """Test list_directories handles du command failures for size ordering."""
-        # Mock du command to return non-zero returncode
-        mocker.patch(
-            "linux_mcp_server.tools.storage.execute_command",
-            AsyncMock(return_value=(1, "", "du: cannot read directory")),
-        )
-
-        with pytest.raises(ToolError, match="Error executing tool list_directories"):
-            await mcp.call_tool(
-                "list_directories",
-                {"path": "/some/path", "order_by": "size", "host": "remote.server.com"},
-            )
-
-    async def test_list_directories_find_command_failure_name(self, mocker):
-        """Test list_directories handles find command failures for name ordering."""
-        # Mock find command to return non-zero returncode
-        mocker.patch(
-            "linux_mcp_server.tools.storage.execute_command",
-            AsyncMock(return_value=(1, "", "find: '/some/path': Permission denied")),
-        )
-
-        with pytest.raises(ToolError, match="Error executing tool list_directories"):
-            await mcp.call_tool(
-                "list_directories",
-                {"path": "/some/path", "order_by": "name", "host": "remote.server.com"},
-            )
-
-    async def test_list_directories_find_command_failure_modified(self, mocker):
-        """Test list_directories handles find command failures for modified ordering."""
-        # Mock find command to return non-zero returncode
-        mocker.patch(
-            "linux_mcp_server.tools.storage.execute_command",
-            AsyncMock(return_value=(1, "", "find: '/some/path': Permission denied")),
-        )
+        got = parse_node_result(result)
+        assert len(got) == 2
+        assert got[0].modified == 0.0  # Default value
+        assert got[1].modified == 0.0  # Also missing mtime
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="requires GNU version of coreutils/findutils")
 class TestListFiles:
-    async def test_list_files_returns_structured_output(self, setup_test_files):
+    async def test_list_files_returns_structured_output(self, setup_test_nodes):
         """Test that list_files returns structured output."""
-        file_specs = [
-            ("alpha", 100, 1000.0),
-            ("beta", 200, 2000.0),
-            ("gamma", 300, 3000.0),
-        ]
-        test_path, _ = setup_test_files(file_specs)
+        test_path, _ = setup_test_nodes(ALPHA_BETA_GAMMA_SPECS, "file")
 
         result = await mcp.call_tool("list_files", {"path": str(test_path), "order_by": "name"})
 
-        # Verify the entire result structure
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        files = list[NodeEntry](result[1]["result"])
-        assert files is not None
+        got = parse_node_result(result)
+        assert got is not None
 
-    async def test_list_files_by_name(self, setup_test_files):
-        """Test that list_files returns structured output sorted by name."""
-        dir_specs = [
-            ("alpha", 100, 1000.0),
-            ("beta", 200, 2000.0),
-            ("gamma", 300, 3000.0),
-        ]
-        test_path, _ = setup_test_files(dir_specs)
+    @pytest.mark.parametrize(
+        ("order_by", "sort", "specs", "expected"),
+        [
+            pytest.param(
+                "name",
+                "ascending",
+                ALPHA_BETA_GAMMA_SPECS,
+                [
+                    NodeEntry(name="alpha", size=0, modified=0.0),
+                    NodeEntry(name="beta", size=0, modified=0.0),
+                    NodeEntry(name="gamma", size=0, modified=0.0),
+                ],
+                id="name_ascending",
+            ),
+            pytest.param(
+                "name",
+                "descending",
+                ALPHA_BETA_GAMMA_SPECS,
+                [
+                    NodeEntry(name="gamma", size=0, modified=0.0),
+                    NodeEntry(name="beta", size=0, modified=0.0),
+                    NodeEntry(name="alpha", size=0, modified=0.0),
+                ],
+                id="name_descending",
+            ),
+            pytest.param(
+                "size",
+                "ascending",
+                SIZE_ORDERED_SPECS,
+                [
+                    NodeEntry(name="small", size=100, modified=0.0),
+                    NodeEntry(name="medium", size=200, modified=0.0),
+                    NodeEntry(name="large", size=300, modified=0.0),
+                ],
+                id="size_ascending",
+            ),
+            pytest.param(
+                "size",
+                "descending",
+                SIZE_ORDERED_SPECS,
+                [
+                    NodeEntry(name="large", size=300, modified=0.0),
+                    NodeEntry(name="medium", size=200, modified=0.0),
+                    NodeEntry(name="small", size=100, modified=0.0),
+                ],
+                id="size_descending",
+            ),
+            pytest.param(
+                "modified",
+                "ascending",
+                TIME_ORDERED_SPECS,
+                [
+                    NodeEntry(name="oldest", size=0, modified=1000.0),
+                    NodeEntry(name="middle", size=0, modified=2000.0),
+                    NodeEntry(name="newest", size=0, modified=3000.0),
+                ],
+                id="modified_ascending",
+            ),
+            pytest.param(
+                "modified",
+                "descending",
+                TIME_ORDERED_SPECS,
+                [
+                    NodeEntry(name="newest", size=0, modified=3000.0),
+                    NodeEntry(name="middle", size=0, modified=2000.0),
+                    NodeEntry(name="oldest", size=0, modified=1000.0),
+                ],
+                id="modified_descending",
+            ),
+        ],
+    )
+    async def test_list_files_ordering(self, setup_test_nodes, order_by, sort, specs, expected):
+        """Test list_files with various orderings and sort directions."""
+        test_path, _ = setup_test_nodes(specs, "file")
 
-        # When ordering by name, only the name field is populated
-        expected_entries = [
-            NodeEntry(name="alpha", size=0, modified=0.0),
-            NodeEntry(name="beta", size=0, modified=0.0),
-            NodeEntry(name="gamma", size=0, modified=0.0),
-        ]
+        result = await mcp.call_tool("list_files", {"path": str(test_path), "order_by": order_by, "sort": sort})
 
-        result = await mcp.call_tool("list_files", {"path": str(test_path), "order_by": "name"})
+        got = parse_node_result(result)
+        assert got == expected
 
-        # Verify the structured output
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
-
-    async def test_list_files_by_size(self, setup_test_files):
-        """Test that list_files returns structured output sorted by size."""
-        dir_specs = [
-            ("small", 100, 1000.0),
-            ("large", 300, 3000.0),
-            ("medium", 200, 2000.0),
-        ]
-        test_path, _ = setup_test_files(dir_specs)
-
-        expected_entries = [
-            NodeEntry(name="small", size=100, modified=0.0),
-            NodeEntry(name="medium", size=200, modified=0.0),
-            NodeEntry(name="large", size=300, modified=0.0),
-        ]
-
-        result = await mcp.call_tool("list_files", {"path": str(test_path), "order_by": "size", "sort": "ascending"})
-
-        # Verify the structured output - should be sorted by size (ascending)
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
-
-    async def test_list_files_by_modified(self, setup_test_files):
-        """Test that list_files returns structured output sorted by modification time."""
-        dir_specs = [
-            ("newest", 0, 3000.0),
-            ("oldest", 100, 1000.0),
-            ("middle", 100, 2000.0),
-        ]
-        test_path, _ = setup_test_files(dir_specs)
-
-        # When ordering by modified, only name and modified fields are populated
-        expected_entries = [
-            NodeEntry(name="oldest", size=0, modified=1000.0),
-            NodeEntry(name="middle", size=0, modified=2000.0),
-            NodeEntry(name="newest", size=0, modified=3000.0),
-        ]
-
-        result = await mcp.call_tool(
-            "list_files", {"path": str(test_path), "order_by": "modified", "sort": "ascending"}
-        )
-
-        # Verify the structured output - should be sorted by modification time (ascending)
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
-
-    async def test_list_files_by_name_with_top_n(self, setup_test_files):
-        """Test that list_files returns structured output sorted by name with top_n limit."""
-        dir_specs = [
-            ("alpha", 100, 1000.0),
-            ("beta", 200, 2000.0),
-            ("gamma", 300, 3000.0),
-        ]
-        test_path, _ = setup_test_files(dir_specs)
-
-        # When ordering by name, only name field is populated
-        expected_entries = [
-            NodeEntry(name="alpha", size=0, modified=0.0),
-            NodeEntry(name="beta", size=0, modified=0.0),
-        ]
-
-        result = await mcp.call_tool("list_files", {"path": str(test_path), "order_by": "name", "top_n": 2})
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
-
-    async def test_list_files_by_name_descending(self, setup_test_files):
-        """Test that list_files returns structured output sorted by name in descending order."""
-        dir_specs = [
-            ("alpha", 100, 1000.0),
-            ("beta", 200, 2000.0),
-            ("gamma", 300, 3000.0),
-        ]
-        test_path, _ = setup_test_files(dir_specs)
-
-        expected_entries = [
-            NodeEntry(name="gamma", size=0, modified=0.0),
-            NodeEntry(name="beta", size=0, modified=0.0),
-            NodeEntry(name="alpha", size=0, modified=0.0),
-        ]
-
-        result = await mcp.call_tool("list_files", {"path": str(test_path), "order_by": "name", "sort": "descending"})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
-
-    async def test_list_files_by_size_descending(self, setup_test_files):
-        """Test that list_files returns structured output sorted by size in descending order."""
-        dir_specs = [
-            ("small", 100, 1000.0),
-            ("large", 300, 3000.0),
-            ("medium", 200, 2000.0),
-        ]
-        test_path, _ = setup_test_files(dir_specs)
-
-        expected_entries = [
-            NodeEntry(name="large", size=300, modified=0.0),
-            NodeEntry(name="medium", size=200, modified=0.0),
-            NodeEntry(name="small", size=100, modified=0.0),
-        ]
-
-        result = await mcp.call_tool("list_files", {"path": str(test_path), "order_by": "size", "sort": "descending"})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
-
-    async def test_list_files_by_modified_descending(self, setup_test_files):
-        """Test that list_files returns structured output sorted by modified time in descending order."""
-        dir_specs = [
-            ("newest", 100, 3000.0),
-            ("oldest", 100, 1000.0),
-            ("middle", 100, 2000.0),
-        ]
-        test_path, _ = setup_test_files(dir_specs)
-
-        expected_entries = [
-            NodeEntry(name="newest", size=0, modified=3000.0),
-            NodeEntry(name="middle", size=0, modified=2000.0),
-            NodeEntry(name="oldest", size=0, modified=1000.0),
-        ]
+    @pytest.mark.parametrize(
+        ("order_by", "specs", "top_n", "expected_names"),
+        [
+            pytest.param("name", ALPHA_BETA_GAMMA_SPECS, 2, ["alpha", "beta"], id="name_top_2"),
+            pytest.param("modified", TIME_ORDERED_SPECS, 2, ["oldest", "middle"], id="modified_top_2"),
+        ],
+    )
+    async def test_list_files_with_top_n(self, setup_test_nodes, order_by, specs, top_n, expected_names):
+        """Test list_files with top_n limit."""
+        test_path, _ = setup_test_nodes(specs, "file")
 
         result = await mcp.call_tool(
-            "list_files", {"path": str(test_path), "order_by": "modified", "sort": "descending"}
+            "list_files", {"path": str(test_path), "order_by": order_by, "sort": "ascending", "top_n": top_n}
         )
 
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
+        got = parse_node_result(result)
+        assert [entry.name for entry in got] == expected_names
 
-    async def test_list_files_invalid_order_by(self, tmp_path):
-        """Test that invalid order_by parameter raises ValueError."""
-        with pytest.raises(ToolError, match="1 validation error"):
-            await mcp.call_tool("list_files", {"path": str(tmp_path), "order_by": "invalid"})
+    async def test_list_files_by_size_with_top_n_descending(self, setup_test_nodes):
+        """Test list_files with size ordering, top_n limit, and descending order."""
+        specs = [("small", 100, 1000.0), ("large", 300, 3000.0), ("medium", 200, 2000.0), ("tiny", 50, 500.0)]
+        test_path, _ = setup_test_nodes(specs, "file")
 
-    async def test_list_files_invalid_sort(self, tmp_path):
-        """Test that invalid sort parameter raises ValueError."""
-        with pytest.raises(ToolError, match="1 validation error"):
-            await mcp.call_tool("list_files", {"path": str(tmp_path), "sort": "invalid"})
-
-    async def test_list_files_invalid_path(self, tmp_path):
-        """Test with non-existent path raises ToolError."""
-        non_existent_path = tmp_path / "non_existent_directory"
-        with pytest.raises(ToolError, match="Path does not exist or cannot be resolved"):
-            await mcp.call_tool("list_files", {"path": str(non_existent_path), "order_by": "name"})
-
-    async def test_list_files_handles_permission_denied(self, restricted_path):
-        """Test handling of permission denied errors gracefully."""
-        with pytest.raises(ToolError, match="Permission denied to read"):
-            await mcp.call_tool("list_files", {"path": str(restricted_path)})
-
-    async def test_list_files_empty_directory_by_name(self, tmp_path):
-        """Test list_files with a directory containing no subfiles (name ordering)."""
-        result = await mcp.call_tool("list_files", {"path": str(tmp_path), "order_by": "name"})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == []
-
-    async def test_list_files_empty_directory_by_size(self, tmp_path):
-        """Test list_files with a directory containing no subfiles (size ordering)."""
-        result = await mcp.call_tool("list_files", {"path": str(tmp_path), "order_by": "size"})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == []
-
-    async def test_list_files_empty_directory_by_modified(self, tmp_path):
-        """Test list_files with a directory containing no subfiles (modified ordering)."""
-        result = await mcp.call_tool("list_files", {"path": str(tmp_path), "order_by": "modified"})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == []
-
-    async def test_list_files_special_characters_in_names(self, tmp_path):
-        """Test list_files handles directory names with special characters."""
-        # Create files with special characters
-        (tmp_path / "file with spaces").touch()
-        (tmp_path / "file-with-dashes").touch()
-        (tmp_path / "file_with_underscores").touch()
-        (tmp_path / "file_with_@@$!($)@").touch()
-        (tmp_path / "file_with_📁.txt").touch()
-        (tmp_path / "file_with_✨.md").touch()
-        (tmp_path / "file_with_question?.txt").touch()
-        (tmp_path / "file_with_angle<test>.log").touch()
-        (tmp_path / "file_with_pipe|symbol.txt").touch()
-        (tmp_path / "file_with_colon:check.md").touch()
-
-        result = await mcp.call_tool("list_files", {"path": str(tmp_path), "order_by": "name"})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-
-        # Verify all directory names are correctly parsed
-        names = [entry.name for entry in got]
-        assert "file with spaces" in names
-        assert "file-with-dashes" in names
-        assert "file_with_underscores" in names
-        assert len(got) == 10
-
-    async def test_list_files_by_modified_with_top_n(self, setup_test_files):
-        """Test that list_files returns structured output sorted by modified time with top_n limit."""
-        dir_specs = [
-            ("newest", 100, 3000.0),
-            ("oldest", 100, 1000.0),
-            ("middle", 100, 2000.0),
-        ]
-        test_path, _ = setup_test_files(dir_specs)
-
-        expected_entries = [
-            NodeEntry(name="oldest", size=0, modified=1000.0),
-            NodeEntry(name="middle", size=0, modified=2000.0),
-        ]
-
-        result = await mcp.call_tool(
-            "list_files", {"path": str(test_path), "order_by": "modified", "sort": "ascending", "top_n": 2}
-        )
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
-
-    async def test_list_files_by_size_with_top_n_descending(self, setup_test_files):
-        """Test that list_files returns structured output sorted by size with top_n limit and descending order."""
-        dir_specs = [
-            ("small", 100, 1000.0),
-            ("large", 300, 3000.0),
-            ("medium", 200, 2000.0),
-            ("tiny", 50, 500.0),
-        ]
-        test_path, _ = setup_test_files(dir_specs)
-
-        expected_entries = [
+        expected = [
             NodeEntry(name="large", size=300, modified=0.0),
             NodeEntry(name="medium", size=200, modified=0.0),
         ]
@@ -1072,367 +578,294 @@ class TestListFiles:
             "list_files", {"path": str(test_path), "order_by": "size", "sort": "descending", "top_n": 2}
         )
 
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
-        assert got == expected_entries
+        got = parse_node_result(result)
+        assert got == expected
 
-    async def test_list_files_remote_execution_by_size(self, mocker):
-        """Test list_files with remote execution for size ordering."""
-        # Mock du command output
-        mock_execute_command = mocker.patch(
-            "linux_mcp_server.tools.storage.execute_command",
-            AsyncMock(
-                return_value=(
-                    0,
-                    "100\t/remote/path/small\n300\t/remote/path/large\n200\t/remote/path/medium\n500\t/remote/path",
-                    "",
-                )
+    @pytest.mark.parametrize("order_by", ["name", "size", "modified"])
+    async def test_list_files_empty_directory(self, tmp_path, order_by):
+        """Test list_files with a directory containing no files."""
+        result = await mcp.call_tool("list_files", {"path": str(tmp_path), "order_by": order_by})
+
+        got = parse_node_result(result)
+        assert got == []
+
+    @pytest.mark.parametrize(
+        ("param", "value", "error_match"),
+        [
+            pytest.param("order_by", "invalid", "1 validation error", id="invalid_order_by"),
+            pytest.param("sort", "invalid", "1 validation error", id="invalid_sort"),
+        ],
+    )
+    async def test_list_files_invalid_params(self, tmp_path, param, value, error_match):
+        """Test that invalid parameters raise ValueError."""
+        params = {"path": str(tmp_path), param: value}
+        with pytest.raises(ToolError, match=error_match):
+            await mcp.call_tool("list_files", params)
+
+    async def test_list_files_invalid_path(self, tmp_path):
+        """Test with non-existent path returns empty results via Ansible."""
+        non_existent_path = tmp_path / "non_existent_directory"
+        result = await mcp.call_tool("list_files", {"path": str(non_existent_path), "order_by": "name"})
+
+        got = parse_node_result(result)
+        assert got == []
+
+    async def test_list_files_handles_permission_denied(self, restricted_path):
+        """Test handling of permission denied returns empty results via Ansible."""
+        result = await mcp.call_tool("list_files", {"path": str(restricted_path)})
+
+        got = parse_node_result(result)
+        assert got == []
+
+    async def test_list_files_special_characters_in_names(self, tmp_path):
+        """Test list_files handles file names with special characters."""
+        special_names = [
+            "file with spaces",
+            "file-with-dashes",
+            "file_with_underscores",
+            "file_with_@@$!($)@",
+            "file_with_📁.txt",
+            "file_with_✨.md",
+            "file_with_question?.txt",
+            "file_with_angle<test>.log",
+            "file_with_pipe|symbol.txt",
+            "file_with_colon:check.md",
+        ]
+        for name in special_names:
+            (tmp_path / name).touch()
+
+        result = await mcp.call_tool("list_files", {"path": str(tmp_path), "order_by": "name"})
+
+        got = parse_node_result(result)
+        names = [entry.name for entry in got]
+        for expected in special_names:
+            assert expected in names
+        assert len(got) == 10
+
+    @pytest.mark.parametrize(
+        ("order_by", "files", "expected"),
+        [
+            pytest.param(
+                "size",
+                [
+                    {"path": "/remote/path/small.txt", "size": 100, "mtime": 1000.0},
+                    {"path": "/remote/path/large.txt", "size": 300, "mtime": 3000.0},
+                    {"path": "/remote/path/medium.txt", "size": 200, "mtime": 2000.0},
+                ],
+                [
+                    NodeEntry(name="small.txt", size=100, modified=0.0),
+                    NodeEntry(name="medium.txt", size=200, modified=0.0),
+                    NodeEntry(name="large.txt", size=300, modified=0.0),
+                ],
+                id="size_ordering",
             ),
-        )
+            pytest.param(
+                "name",
+                [
+                    {"path": "/remote/path/gamma.txt", "size": 300, "mtime": 3000.0},
+                    {"path": "/remote/path/alpha.txt", "size": 100, "mtime": 1000.0},
+                    {"path": "/remote/path/beta.txt", "size": 200, "mtime": 2000.0},
+                ],
+                [
+                    NodeEntry(name="alpha.txt", size=0, modified=0.0),
+                    NodeEntry(name="beta.txt", size=0, modified=0.0),
+                    NodeEntry(name="gamma.txt", size=0, modified=0.0),
+                ],
+                id="name_ordering",
+            ),
+            pytest.param(
+                "modified",
+                [
+                    {"path": "/remote/path/newest.txt", "size": 100, "mtime": 3000.0},
+                    {"path": "/remote/path/oldest.txt", "size": 100, "mtime": 1000.0},
+                    {"path": "/remote/path/middle.txt", "size": 100, "mtime": 2000.0},
+                ],
+                [
+                    NodeEntry(name="oldest.txt", size=0, modified=1000.0),
+                    NodeEntry(name="middle.txt", size=0, modified=2000.0),
+                    NodeEntry(name="newest.txt", size=0, modified=3000.0),
+                ],
+                id="modified_ordering",
+            ),
+        ],
+    )
+    async def test_list_files_ansible_execution(self, mocker, order_by, files, expected):
+        """Test list_files with Ansible execution for various orderings."""
+        mock_ansible = AsyncMock(return_value={"files": files})
+        mocker.patch("linux_mcp_server.tools.storage.execute_ansible_module", mock_ansible)
 
         result = await mcp.call_tool(
             "list_files",
-            {"path": "/remote/path", "order_by": "size", "host": "remote.server.com"},
+            {"path": "/remote/path", "order_by": order_by, "host": "remote.server.com"},
         )
 
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
+        got = parse_node_result(result)
+        assert got == expected
 
-        # Verify results are sorted by size
-        assert len(got) == 3
-        assert got[0].name == "small"
-        assert got[0].size == 100
-        assert got[1].name == "medium"
-        assert got[1].size == 200
-        assert got[2].name == "large"
-        assert got[2].size == 300
-
-        # Verify execute_command was called with host
-        mock_execute_command.assert_called_once()
-        call_kwargs = mock_execute_command.call_args[1]
+        call_kwargs = mock_ansible.call_args[1]
+        assert call_kwargs["module"] == "find"
+        assert call_kwargs["module_args"]["file_type"] == "file"
         assert call_kwargs["host"] == "remote.server.com"
 
-    async def test_list_files_remote_execution_by_name(self, mocker):
-        """Test list_files with remote execution for name ordering."""
-        mock_execute_command = mocker.patch(
-            "linux_mcp_server.tools.storage.execute_command",
-            AsyncMock(
-                return_value=(
-                    0,
-                    "gamma\nalpha\nbeta",
-                    "",
-                )
-            ),
-        )
+    async def test_list_files_ansible_descending(self, mocker):
+        """Test list_files with Ansible and descending sort."""
+        files = [
+            {"path": "/remote/path/small.txt", "size": 100, "mtime": 1000.0},
+            {"path": "/remote/path/large.txt", "size": 300, "mtime": 3000.0},
+            {"path": "/remote/path/medium.txt", "size": 200, "mtime": 2000.0},
+        ]
+        mock_ansible = AsyncMock(return_value={"files": files})
+        mocker.patch("linux_mcp_server.tools.storage.execute_ansible_module", mock_ansible)
 
         result = await mcp.call_tool(
             "list_files",
-            {"path": "/remote/path", "order_by": "name", "host": "remote.server.com"},
+            {"path": "/remote/path", "order_by": "size", "sort": "descending", "host": "remote.server.com"},
         )
 
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
+        got = parse_node_result(result)
+        assert [e.name for e in got] == ["large.txt", "medium.txt", "small.txt"]
+        assert got[0].size == 300
 
-        # Verify results are sorted by name
-        assert len(got) == 3
-        assert got[0].name == "alpha"
-        assert got[1].name == "beta"
-        assert got[2].name == "gamma"
-
-        # Verify execute_command was called with host
-        mock_execute_command.assert_called_once()
-        call_kwargs = mock_execute_command.call_args[1]
-        assert call_kwargs["host"] == "remote.server.com"
-
-    async def test_list_files_remote_execution_by_modified(self, mocker):
-        """Test list_files with remote execution for modified ordering."""
-        mock_execute_command = mocker.patch(
-            "linux_mcp_server.tools.storage.execute_command",
-            AsyncMock(
-                return_value=(
-                    0,
-                    "3000.0\tnewest\n1000.0\toldest\n2000.0\tmiddle",
-                    "",
-                )
-            ),
-        )
+    async def test_list_files_ansible_with_top_n(self, mocker):
+        """Test list_files with Ansible and top_n limit."""
+        files = [
+            {"path": "/remote/path/small.txt", "size": 100, "mtime": 1000.0},
+            {"path": "/remote/path/large.txt", "size": 300, "mtime": 3000.0},
+            {"path": "/remote/path/medium.txt", "size": 200, "mtime": 2000.0},
+        ]
+        mock_ansible = AsyncMock(return_value={"files": files})
+        mocker.patch("linux_mcp_server.tools.storage.execute_ansible_module", mock_ansible)
 
         result = await mcp.call_tool(
             "list_files",
-            {"path": "/remote/path", "order_by": "modified", "host": "remote.server.com"},
+            {"path": "/remote/path", "order_by": "size", "top_n": 2, "host": "remote.server.com"},
         )
 
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[1], dict)
-        got = [NodeEntry(**entry) for entry in result[1]["result"]]
+        got = parse_node_result(result)
+        assert len(got) == 2
+        assert [e.name for e in got] == ["small.txt", "medium.txt"]
 
-        # Verify results are sorted by modified time
-        assert len(got) == 3
-        assert got[0].name == "oldest"
-        assert got[0].modified == 1000.0
-        assert got[1].name == "middle"
-        assert got[1].modified == 2000.0
-        assert got[2].name == "newest"
-        assert got[2].modified == 3000.0
+    async def test_list_files_ansible_empty_results(self, mocker):
+        """Test list_files with Ansible returns empty list for no matches."""
+        mock_ansible = AsyncMock(return_value={"files": []})
+        mocker.patch("linux_mcp_server.tools.storage.execute_ansible_module", mock_ansible)
 
-        # Verify execute_command was called with host
-        mock_execute_command.assert_called_once()
-        call_kwargs = mock_execute_command.call_args[1]
-        assert call_kwargs["host"] == "remote.server.com"
-
-    async def test_list_files_remote_skips_path_validation(self, mocker):
-        """Test that remote execution skips local path validation."""
-        # Mock du command output
-        mocker.patch(
-            "linux_mcp_server.tools.storage.execute_command",
-            AsyncMock(
-                return_value=(
-                    0,
-                    "100\t/nonexistent/path",
-                    "",
-                )
-            ),
-        )
-
-        # This path doesn't e'xist locally but should not raise an error for remote execution
         result = await mcp.call_tool(
             "list_files",
-            {"path": "/nonexistent/remote/path", "order_by": "size", "host": "remote.server.com"},
+            {"path": "/remote/empty", "order_by": "name", "host": "remote.server.com"},
         )
 
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        # Should succeed even though path doesn't exist locally
-        assert isinstance(result[1], dict)
-
-    @pytest.mark.parametrize(("order_by"), (("size",), ("name",), ("modified",)))
-    async def test_list_files_find_command_failure_order_by(self, mocker, order_by):
-        """Test list_files handles find command failures for size ordering."""
-        # Mock du command to return non-zero returncode
-        mocker.patch(
-            "linux_mcp_server.tools.storage.execute_command",
-            return_value=(1, "", "find: '/some/path': Permission denied"),
-        )
-
-        with pytest.raises(ToolError, match="Error executing tool list_files"):
-            await mcp.call_tool(
-                "list_files",
-                {"path": "/some/path", "order_by": order_by, "host": "remote.server.com"},
-            )
+        got = parse_node_result(result)
+        assert got == []
 
 
 class TestReadFile:
-    async def test_read_file_success(self, tmp_path):
-        """Test read_file with a valid file."""
-        # Create a test file
+    @pytest.mark.parametrize(
+        ("content", "description"),
+        [
+            pytest.param("Hello, World!\nThis is a test file.\nLine 3.", "normal text", id="normal"),
+            pytest.param("", "empty file", id="empty"),
+            pytest.param(
+                "Line with\ttabs\nLine with 'quotes'\nLine with \"double quotes\"\n$pecial ch@rs: !@#$%",
+                "special characters",
+                id="special_chars",
+            ),
+            pytest.param("Hello 世界\nBonjour 🌍\n한글", "unicode content", id="unicode"),
+            pytest.param("\n".join([f"Line {i}" for i in range(1000)]), "large file", id="large"),
+        ],
+    )
+    async def test_read_file_content(self, tmp_path, content, description):
+        """Test read_file with various content types."""
         test_file = tmp_path / "test.txt"
-        test_content = "Hello, World!\nThis is a test file.\nLine 3."
-        test_file.write_text(test_content)
-
-        result = await mcp.call_tool("read_file", {"path": str(test_file)})
-
-        # Verify result structure
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[0], list)
-        output = result[0][0].text
-
-        assert output == test_content
-
-    async def test_read_file_empty_file(self, tmp_path):
-        """Test read_file with an empty file."""
-        test_file = tmp_path / "empty.txt"
-        test_file.write_text("")
+        test_file.write_text(content)
 
         result = await mcp.call_tool("read_file", {"path": str(test_file)})
 
         assert isinstance(result, tuple)
         assert len(result) == 2
-        assert isinstance(result[0], list)
-        output = result[0][0].text
+        output = result[0][0].text  # pyright: ignore[reportIndexIssue]
+        assert output == content
 
-        assert output == ""
-
-    async def test_read_file_nonexistent(self, tmp_path):
-        """Test read_file with a non-existent file."""
-        non_existent_file = tmp_path / "nonexistent.txt"
-
-        with pytest.raises(ToolError, match="Path does not exist"):
-            await mcp.call_tool("read_file", {"path": str(non_existent_file)})
-
-    async def test_read_file_directory_not_file(self, tmp_path):
-        """Test read_file with a directory path instead of a file."""
-        with pytest.raises(ToolError, match="Path is not a file"):
-            await mcp.call_tool("read_file", {"path": str(tmp_path)})
+    @pytest.mark.parametrize(
+        ("setup_fn", "error_match"),
+        [
+            pytest.param(lambda p: p / "nonexistent.txt", "Error executing tool read_file", id="nonexistent"),
+            pytest.param(lambda p: p, "Error executing tool read_file", id="directory_not_file"),
+        ],
+    )
+    async def test_read_file_errors(self, tmp_path, setup_fn, error_match):
+        """Test read_file error cases."""
+        path = setup_fn(tmp_path)
+        with pytest.raises(ToolError, match=error_match):
+            await mcp.call_tool("read_file", {"path": str(path)})
 
     async def test_read_file_permission_denied(self, tmp_path):
-        """Test read_file with a file that has no read permissions."""
+        """Test read_file with a file that has no read permissions raises ToolError."""
         restricted_file = tmp_path / "restricted.txt"
         restricted_file.write_text("secret content")
         restricted_file.chmod(0o000)
 
         try:
-            with pytest.raises(ToolError, match="Permission denied"):
+            with pytest.raises(ToolError, match="Error executing tool read_file"):
                 await mcp.call_tool("read_file", {"path": str(restricted_file)})
         finally:
-            # Restore permissions for cleanup
             restricted_file.chmod(0o644)
-
-    async def test_read_file_with_special_characters(self, tmp_path):
-        """Test read_file with content containing special characters."""
-        test_file = tmp_path / "special.txt"
-        special_content = "Line with\ttabs\nLine with 'quotes'\nLine with \"double quotes\"\n$pecial ch@rs: !@#$%"
-        test_file.write_text(special_content)
-
-        result = await mcp.call_tool("read_file", {"path": str(test_file)})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[0], list)
-        output = result[0][0].text
-
-        assert output == special_content
-
-    async def test_read_file_with_unicode(self, tmp_path):
-        """Test read_file with unicode content."""
-        test_file = tmp_path / "unicode.txt"
-        unicode_content = "Hello 世界\nBonjour 🌍\n한글"
-        test_file.write_text(unicode_content)
-
-        result = await mcp.call_tool("read_file", {"path": str(test_file)})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[0], list)
-        output = result[0][0].text
-
-        assert output == unicode_content
-
-    async def test_read_file_large_file(self, tmp_path):
-        """Test read_file with a relatively large file."""
-        test_file = tmp_path / "large.txt"
-        # Create a file with 1000 lines
-        large_content = "\n".join([f"Line {i}" for i in range(1000)])
-        test_file.write_text(large_content)
-
-        result = await mcp.call_tool("read_file", {"path": str(test_file)})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[0], list)
-        output = result[0][0].text
-
-        assert output == large_content
-        assert "Line 0" in output
-        assert "Line 999" in output
-
-    async def test_read_file_remote_execution(self, mocker):
-        """Test read_file with remote execution."""
-        mock_content = "Remote file content\nLine 2\nLine 3"
-        mock_execute_command = mocker.patch(
-            "linux_mcp_server.tools.storage.execute_command", AsyncMock(return_value=(0, mock_content, ""))
-        )
-
-        result = await mcp.call_tool("read_file", {"path": "/remote/path/file.txt", "host": "remote.host.com"})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[0], list)
-        output = result[0][0].text
-
-        assert output == mock_content
-
-        # Verify execute_command was called with correct arguments
-        mock_execute_command.assert_called_once()
-        args = mock_execute_command.call_args[0][0]
-        assert args[0] == "cat"
-        assert args[1] == "/remote/path/file.txt"
-        call_kwargs = mock_execute_command.call_args[1]
-        assert call_kwargs["host"] == "remote.host.com"
-
-    async def test_read_file_remote_command_failure(self, mocker):
-        """Test read_file handles command failures for remote execution."""
-        mocker.patch(
-            "linux_mcp_server.tools.storage.execute_command",
-            AsyncMock((1, "", "cat: /remote/file.txt: No such file or directory")),
-        )
-
-        with pytest.raises(ToolError, match="Error executing tool read_file"):
-            await mcp.call_tool("read_file", {"path": "/remote/file.txt", "host": "remote.host.com"})
-
-    async def test_read_file_remote_skips_path_validation(self, mocker):
-        """Test that remote execution skips local path validation."""
-        mocker.patch(
-            "linux_mcp_server.tools.storage.execute_command", AsyncMock(return_value=(0, "Remote content", ""))
-        )
-
-        # This path doesn't exist locally but should not raise an error for remote execution
-        result = await mcp.call_tool("read_file", {"path": "/nonexistent/remote/file.txt", "host": "remote.server.com"})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        # Should succeed even though path doesn't exist locally
-        assert isinstance(result[0], list)
-
-    async def test_read_file_remote_empty_output(self, mocker):
-        """Test read_file with remote execution returning empty content."""
-        mocker.patch("linux_mcp_server.tools.storage.execute_command", AsyncMock(return_value=(0, "", "")))
-
-        result = await mcp.call_tool("read_file", {"path": "/remote/empty.txt", "host": "remote.host.com"})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[0], list)
-        output = result[0][0].text
-
-        assert output == ""
-
-    async def test_read_file_with_relative_path(self, tmp_path):
-        """Test read_file resolves relative paths correctly."""
-        test_file = tmp_path / "test.txt"
-        test_content = "Content"
-        test_file.write_text(test_content)
-
-        # Change to tmp_path directory and use relative path
-        import os
-
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-            result = await mcp.call_tool("read_file", {"path": "test.txt"})
-
-            assert isinstance(result, tuple)
-            assert len(result) == 2
-            assert isinstance(result[0], list)
-            output = result[0][0].text
-
-            assert output == test_content
-        finally:
-            os.chdir(original_cwd)
 
     async def test_read_file_with_symlink(self, tmp_path):
         """Test read_file follows symlinks correctly."""
-        # Create a real file
         real_file = tmp_path / "real.txt"
         test_content = "Real content"
         real_file.write_text(test_content)
 
-        # Create a symlink
         symlink_file = tmp_path / "link.txt"
         symlink_file.symlink_to(real_file)
 
         result = await mcp.call_tool("read_file", {"path": str(symlink_file)})
 
         assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[0], list)
-        output = result[0][0].text
-
+        output = result[0][0].text  # pyright: ignore[reportIndexIssue]
         assert output == test_content
+
+    @pytest.mark.parametrize(
+        ("content", "description"),
+        [
+            pytest.param("Remote file content\nLine 2\nLine 3", "normal text", id="normal"),
+            pytest.param("", "empty file", id="empty"),
+            pytest.param("Hello 世界\nBonjour 🌍\n한글", "unicode content", id="unicode"),
+        ],
+    )
+    async def test_read_file_ansible_execution(self, mocker, content, description):
+        """Test read_file with Ansible slurp module."""
+        content_b64 = base64.b64encode(content.encode()).decode()
+        mock_ansible = AsyncMock(return_value={"content": content_b64})
+        mocker.patch("linux_mcp_server.tools.storage.execute_ansible_module", mock_ansible)
+
+        result = await mcp.call_tool("read_file", {"path": "/remote/path/file.txt", "host": "remote.server.com"})
+
+        assert isinstance(result, tuple)
+        output = result[0][0].text  # pyright: ignore[reportIndexIssue]
+        assert output == content
+
+        call_kwargs = mock_ansible.call_args[1]
+        assert call_kwargs["module"] == "slurp"
+        assert call_kwargs["module_args"]["src"] == "/remote/path/file.txt"
+        assert call_kwargs["host"] == "remote.server.com"
+
+    @pytest.mark.parametrize(
+        ("content_b64", "error_match"),
+        [
+            pytest.param("invalid!!!base64", "Failed to decode file content", id="invalid_base64"),
+            pytest.param(
+                base64.b64encode(b"\xff\xfe\xfd").decode(),
+                "Failed to decode file content",
+                id="binary_decode_error",
+            ),
+        ],
+    )
+    async def test_read_file_ansible_decode_errors(self, mocker, content_b64, error_match):
+        """Test read_file handles decode errors from Ansible."""
+        mock_ansible = AsyncMock(return_value={"content": content_b64})
+        mocker.patch("linux_mcp_server.tools.storage.execute_ansible_module", mock_ansible)
+
+        with pytest.raises(ToolError, match=error_match):
+            await mcp.call_tool("read_file", {"path": "/remote/file.txt", "host": "remote.server.com"})

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
 
@@ -13,6 +14,78 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "ansible-core"
+version = "2.17.14"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "cryptography", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pyyaml", marker = "python_full_version < '3.11'" },
+    { name = "resolvelib", version = "1.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/80/2925a0564f6f99a8002c3be3885b83c3a1dc5f57ebf00163f528889865f5/ansible_core-2.17.14.tar.gz", hash = "sha256:7c17fee39f8c29d70e3282a7e9c10bd70d5cd4fd13ddffc5dcaa52adbd142ff8", size = 3119687, upload-time = "2025-09-08T18:28:03.158Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/29/d694562f1a875b50aa74f691521fe493704f79cf1938cd58f28f7e2327d2/ansible_core-2.17.14-py3-none-any.whl", hash = "sha256:34a49582a57c2f2af17ede2cefd3b3602a2d55d22089f3928570d52030cafa35", size = 2189656, upload-time = "2025-09-08T18:28:00.375Z" },
+]
+
+[[package]]
+name = "ansible-core"
+version = "2.19.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "cryptography", marker = "python_full_version == '3.11.*'" },
+    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
+    { name = "packaging", marker = "python_full_version == '3.11.*'" },
+    { name = "pyyaml", marker = "python_full_version == '3.11.*'" },
+    { name = "resolvelib", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/f7/030452764ef32f11ab7abe61a49ca6ccee777217253753f87b85aafd6183/ansible_core-2.19.5.tar.gz", hash = "sha256:d03660ff32ba8a5ae40a82148cb24b38a35d26c0155621ddd9148b7562fd8be2", size = 3412598, upload-time = "2025-12-09T16:48:44.079Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/aa/547b4c30e72d801bd53b75c0233eb125978b5280b149f00b58d6c8ea26aa/ansible_core-2.19.5-py3-none-any.whl", hash = "sha256:7fa6c052bad2c294284b960d240b4cd227060fd2e3836d381db44d2bcfcdf4b7", size = 2415436, upload-time = "2025-12-09T16:48:42.677Z" },
+]
+
+[[package]]
+name = "ansible-core"
+version = "2.20.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "cryptography", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
+    { name = "resolvelib", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/47/3543ea4e7ad65859c0043e9a03e1da99c57c22dfb29027e9951dd58e7524/ansible_core-2.20.1.tar.gz", hash = "sha256:a891e5f90cd46626778f0f3d545ec1115840c9b50e8adf25944c5e1748452106", size = 3313203, upload-time = "2025-12-09T16:49:57.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/8c/b9ef852c9322bffd08ef72c8d6737922af810920e8ebd6ae5c9c5ac1f623/ansible_core-2.20.1-py3-none-any.whl", hash = "sha256:2a66825b4a53f130b62515e7e2a3d811d544b19b6e8a22d9ef88c55896384cb3", size = 2412350, upload-time = "2025-12-09T16:49:55.562Z" },
+]
+
+[[package]]
+name = "ansible-runner"
+version = "2.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pexpect" },
+    { name = "python-daemon" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/db/65b9e058807d313c495a6f4365cc11234d0391c5843659ddc27cc4bf1677/ansible_runner-2.4.2.tar.gz", hash = "sha256:331d4da8d784e5a76aa9356981c0255f4bb1ba640736efe84b0bd7c73a4ca420", size = 152047, upload-time = "2025-10-14T19:10:50.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/da/19512e72e9cf2b8e7e6345264baa6c7ac1bb0ab128eb19c73a58407c4566/ansible_runner-2.4.2-py3-none-any.whl", hash = "sha256:0bde6cb39224770ff49ccdc6027288f6a98f4ed2ea0c64688b31217033221893", size = 79758, upload-time = "2025-10-14T19:10:48.994Z" },
 ]
 
 [[package]]
@@ -559,7 +632,8 @@ name = "ipython"
 version = "9.8.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
@@ -604,6 +678,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -634,6 +720,10 @@ wheels = [
 name = "linux-mcp-server"
 source = { editable = "." }
 dependencies = [
+    { name = "ansible-core", version = "2.17.14", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ansible-core", version = "2.19.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "ansible-core", version = "2.20.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "ansible-runner" },
     { name = "asyncssh" },
     { name = "bcrypt" },
     { name = "mcp" },
@@ -667,6 +757,8 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ansible-core", specifier = ">=2.15.0,<3.0" },
+    { name = "ansible-runner", specifier = ">=2.3.0,<3.0" },
     { name = "asyncssh", specifier = ">=2.14.0" },
     { name = "bcrypt" },
     { name = "mcp", specifier = ">=0.9.0" },
@@ -695,6 +787,100 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-mock" },
+]
+
+[[package]]
+name = "lockfile"
+version = "0.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/47/72cb04a58a35ec495f96984dddb48232b551aafb95bde614605b754fe6f7/lockfile-0.12.2.tar.gz", hash = "sha256:6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799", size = 20874, upload-time = "2015-11-25T18:29:58.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/22/9460e311f340cb62d26a38c419b1381b8593b0bb6b5d1f056938b086d362/lockfile-0.12.2-py2.py3-none-any.whl", hash = "sha256:6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa", size = 13564, upload-time = "2015-11-25T18:29:51.462Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -1089,6 +1275,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-daemon"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lockfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/37/4f10e37bdabc058a32989da2daf29e57dc59dbc5395497f3d36d5f5e2694/python_daemon-3.1.2.tar.gz", hash = "sha256:f7b04335adc473de877f5117e26d5f1142f4c9f7cd765408f0877757be5afbf4", size = 71576, upload-time = "2024-12-03T08:41:07.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/3c/b88167e2d6785c0e781ee5d498b07472aeb9b6765da3b19e7cc9e0813841/python_daemon-3.1.2-py3-none-any.whl", hash = "sha256:b906833cef63502994ad48e2eab213259ed9bb18d54fa8774dcba2ff7864cec6", size = 30872, upload-time = "2024-12-03T08:41:03.322Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1129,6 +1327,70 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1140,6 +1402,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "resolvelib"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/10/f699366ce577423cbc3df3280063099054c23df70856465080798c6ebad6/resolvelib-1.0.1.tar.gz", hash = "sha256:04ce76cbd63fded2078ce224785da6ecd42b9564b1390793f64ddecbe997b309", size = 21065, upload-time = "2023-03-09T05:10:38.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fc/e9ccf0521607bcd244aa0b3fbd574f71b65e9ce6a112c83af988bbbe2e23/resolvelib-1.0.1-py2.py3-none-any.whl", hash = "sha256:d2da45d1a8dfee81bdd591647783e340ef3bcb104b54c383f70d422ef5cc7dbf", size = 17194, upload-time = "2023-03-09T05:10:36.214Z" },
+]
+
+[[package]]
+name = "resolvelib"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/14/4669927e06631070edb968c78fdb6ce8992e27c9ab2cde4b3993e22ac7af/resolvelib-1.2.1.tar.gz", hash = "sha256:7d08a2022f6e16ce405d60b68c390f054efcfd0477d4b9bd019cc941c28fad1c", size = 24575, upload-time = "2025-10-11T01:07:44.582Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/23/c941a0d0353681ca138489983c4309e0f5095dfd902e1357004f2357ddf2/resolvelib-1.2.1-py3-none-any.whl", hash = "sha256:fb06b66c8da04172d9e72a21d7d06186d8919e32ae5ab5cdf5b9d920be805ac2", size = 18737, upload-time = "2025-10-11T01:07:43.081Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add Ansible PoC for all storage.py tools, removing execute_command dependency entirely. All tools now use Ansible for both local and remote execution.

Changes:
- list_block_devices: uses Ansible setup module (gather_subset: devices)
- list_directories: uses Ansible find module (file_type: directory)
- list_files: uses Ansible find module (file_type: file)
- read_file: uses Ansible slurp module (base64 encoded content)

Removed ~150 lines of SSH command infrastructure:
- ToolExecutionAttributes class
- _validate_path(), _sort_results(), _splitlines(), _perform_tool_calling()
- execute_command import

Updated tests to reflect Ansible behavior:
- Ansible find returns directory inode size, not contents size
- Ansible find returns empty results for non-existent/inaccessible paths
- Removed obsolete SSH command failure tests