### PR TITLE
Set the default log in config

### DIFF
--- a/src/linux_mcp_server/config.py
+++ b/src/linux_mcp_server/config.py
@@ -18,7 +18,7 @@ class Config(BaseSettings):
     user: str = getpass.getuser()
 
     # Logging configuration
-    log_dir: Path | None = None
+    log_dir: Path = Path.home() / ".local" / "share" / "linux-mcp-server" / "logs"
     log_level: UpperCase = "INFO"
     log_retention_days: int = 10
 

--- a/src/linux_mcp_server/logging_config.py
+++ b/src/linux_mcp_server/logging_config.py
@@ -8,16 +8,7 @@ import json
 import logging
 import logging.handlers
 
-from pathlib import Path
-
 from linux_mcp_server.config import CONFIG
-
-
-def get_log_directory() -> Path:
-    """Get the log directory path, creating it if necessary."""
-    log_dir = CONFIG.log_dir if CONFIG.log_dir else Path.home() / ".local" / "share" / "linux-mcp-server" / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    return log_dir
 
 
 def get_log_level() -> int:
@@ -128,7 +119,8 @@ class JSONFormatter(logging.Formatter):
 
 def setup_logging():
     """Set up logging with structured formatters and rotation."""
-    log_dir = get_log_directory()
+    log_dir = CONFIG.log_dir
+    log_dir.mkdir(parents=True, exist_ok=True)
     log_level = get_log_level()
     retention_days = get_retention_days()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -218,13 +218,11 @@ class TestConfigEdgeCases:
         mocker.patch("getpass.getuser", return_value="testuser")
 
         config = Config(
-            log_dir=None,
             allowed_log_paths=None,
             ssh_key_path=None,
             key_passphrase=None,
         )
 
-        assert config.log_dir is None
         assert config.allowed_log_paths is None
         assert config.ssh_key_path is None
         assert config.key_passphrase is None

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -4,37 +4,9 @@ import importlib
 import json
 import logging
 
-from linux_mcp_server.logging_config import get_log_directory
 from linux_mcp_server.logging_config import JSONFormatter
 from linux_mcp_server.logging_config import setup_logging
 from linux_mcp_server.logging_config import StructuredFormatter
-
-
-class TestGetLogDirectory:
-    """Test log directory resolution."""
-
-    def test_default_log_directory(self):
-        """Test default log directory is in user's home."""
-        log_dir = get_log_directory()
-        assert log_dir.is_absolute()
-        assert ".local/share/linux-mcp-server/logs" in str(log_dir)
-
-    def test_custom_log_directory(self, mocker, tmp_path):
-        """Test custom log directory from environment variable."""
-        mocker.patch("linux_mcp_server.config.CONFIG.log_dir", tmp_path)
-
-        log_dir = get_log_directory()
-
-        assert log_dir == tmp_path
-
-    def test_log_directory_created(self, mocker, tmp_path):
-        """Test that log directory is created if it doesn't exist."""
-        log_path = tmp_path / "subdir" / "logs"
-
-        mocker.patch("linux_mcp_server.logging_config.CONFIG.log_dir", log_path)
-        log_dir = get_log_directory()
-        assert log_dir.exists()
-        assert log_dir.is_dir()
 
 
 class TestSetupLogging:


### PR DESCRIPTION
Setting a default value in the config keeps default values in a centralized location. With that change,  `get_log_directory` doesn't do enough to justify keeping.