### PR TITLE
Change data types in ProcessInfo model

### DIFF
--- a/src/linux_mcp_server/parsers.py
+++ b/src/linux_mcp_server/parsers.py
@@ -134,21 +134,25 @@ def parse_ps_output(stdout: str) -> list[ProcessInfo]:
         if len(parts) < 11:
             continue
 
-        processes.append(
-            ProcessInfo(
-                user=parts[0],
-                pid=parts[1],
-                cpu_percent=parts[2],
-                mem_percent=parts[3],
-                vsz=parts[4],
-                rss=parts[5],
-                tty=parts[6],
-                stat=parts[7],
-                start=parts[8],
-                time=parts[9],
-                command=parts[10] if len(parts) > 10 else "",
+        try:
+            processes.append(
+                ProcessInfo(
+                    user=parts[0],
+                    pid=int(parts[1]),
+                    cpu_percent=float(parts[2]),
+                    mem_percent=float(parts[3]),
+                    vsz=int(parts[4]),
+                    rss=int(parts[5]),
+                    tty=parts[6],
+                    stat=parts[7],
+                    start=parts[8],
+                    time=parts[9],
+                    command=parts[10] if len(parts) > 10 else "",
+                )
             )
-        )
+        except ValueError:
+            # Silently skip invalid process lines
+            continue
 
     return processes
 

--- a/src/linux_mcp_server/utils/types.py
+++ b/src/linux_mcp_server/utils/types.py
@@ -54,12 +54,12 @@ class NetworkInterface(BaseModel):
 class ProcessInfo(BaseModel):
     """Parsed process information from ps output."""
 
-    pid: str
+    pid: int
     user: str
-    cpu_percent: str
-    mem_percent: str
-    vsz: str
-    rss: str
+    cpu_percent: float
+    mem_percent: float
+    vsz: int
+    rss: int
     tty: str
     stat: str
     start: str

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -105,12 +105,12 @@ class TestFormatProcessList:
         """Test formatting a single process."""
         processes = [
             ProcessInfo(
-                pid="1",
+                pid=1,
                 user="root",
-                cpu_percent="0.0",
-                mem_percent="0.1",
-                vsz="169436",
-                rss="11892",
+                cpu_percent=0.0,
+                mem_percent=0.1,
+                vsz=169436,
+                rss=11892,
                 tty="?",
                 stat="Ss",
                 start="Dec11",
@@ -127,12 +127,12 @@ class TestFormatProcessList:
         """Test that process list is truncated."""
         processes = [
             ProcessInfo(
-                pid=str(i),
+                pid=i,
                 user="user",
-                cpu_percent="0.0",
-                mem_percent="0.1",
-                vsz="1000",
-                rss="500",
+                cpu_percent=0.0,
+                mem_percent=0.1,
+                vsz=1000,
+                rss=500,
                 tty="?",
                 stat="S",
                 start="Dec11",

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -87,9 +87,15 @@ root         1  0.0  0.1 169436 11892 ?        Ss   Dec11   0:01 /sbin/init"""
         assert len(result) == 1
         proc = result[0]
         assert proc.user == "root"
-        assert proc.pid == "1"
-        assert proc.cpu_percent == "0.0"
-        assert proc.mem_percent == "0.1"
+        assert proc.pid == 1
+        assert proc.cpu_percent == 0.0
+        assert proc.mem_percent == 0.1
+        assert proc.vsz == 169436
+        assert proc.rss == 11892
+        assert proc.tty == "?"
+        assert proc.stat == "Ss"
+        assert proc.start == "Dec11"
+        assert proc.time == "0:01"
         assert proc.command == "/sbin/init"
 
     def test_parse_multiple_processes(self):
@@ -99,6 +105,18 @@ root         1  0.0  0.1 169436 11892 ?        Ss   Dec11   0:01 /sbin/init
 nobody     100  1.5  2.0  50000 20000 ?        S    Dec11   5:00 /usr/bin/app"""
         result = parse_ps_output(stdout)
         assert len(result) == 2
+
+    def test_parse_skips_malformed_lines(self):
+        """Test that malformed lines are skipped (too few parts or invalid values)."""
+        stdout = """USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root         1  0.0  0.1 169436 11892 ?        Ss   Dec11   0:01 /sbin/init
+truncated  line with too few parts
+nobody     abc  1.5  2.0  50000 20000 ?        S    Dec11   5:00 /usr/bin/invalid_pid
+valid      200  0.5  0.5  10000 5000  ?        S    Dec11   1:00 /usr/bin/valid"""
+        result = parse_ps_output(stdout)
+        assert len(result) == 2
+        assert result[0].pid == 1
+        assert result[1].pid == 200
 
 
 class TestParseOsRelease:


### PR DESCRIPTION
Make the member fields in ProcessInfo more specific than 'str'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Process parsing is more robust: numeric fields (PID, CPU%, MEM%, VSZ, RSS) are parsed as numbers and malformed lines are skipped.

* **New Features**
  * Parsers now populate additional process attributes (tty, stat, start, time, command) for richer process details.

* **Tests**
  * Tests updated to expect numeric types, the new attributes, and skipping of malformed lines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->