### PR TITLE
Lower coverage targets in .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,7 @@ codecov:
     wait_for_ci: false
 
   require_ci_to_pass: false
-  token: 74bc381b-9c5f-44c1-9efa-af57d5f3fe50  # notsecret  # repo-scoped, upload-only, stability in fork PRs
+  token: 74bc381b-9c5f-44c1-9efa-af57d5f3fe50 # notsecret  # repo-scoped, upload-only, stability in fork PRs
 
 coverage:
   range: 40..100
@@ -25,10 +25,10 @@ coverage:
 
     patch:
       default:
-        target: 100%
+        target: 95%
         threshold: 10%
       app:
-        target: 100%
+        target: 95%
         threshold: 10%
         paths:
           - src/


### PR DESCRIPTION
Reduce patch/app test coverage requirements and we don't need to test our tests. 😆

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration: lowered patch and app coverage targets from 100% to 95%.
  * Made a minor formatting adjustment in the coverage configuration file.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->