### PR TITLE
refactor(tests): simplify remaining network test classes with parameterization

### DIFF
--- a/tests/tools/test_network.py
+++ b/tests/tools/test_network.py
@@ -84,49 +84,55 @@ class TestGetNetworkInterfaces:
 class TestGetNetworkConnections:
     """Test get_network_connections function."""
 
-    async def test_get_network_connections_success(self, mocker):
-        """Test getting network connections with success."""
-        mock_output = """Netid  State      Recv-Q Send-Q Local Address:Port   Peer Address:Port
+    @pytest.mark.parametrize(
+        ("host", "mock_output", "expected_content"),
+        [
+            pytest.param(
+                None,
+                """Netid  State      Recv-Q Send-Q Local Address:Port   Peer Address:Port
 tcp    ESTAB      0      0      192.168.1.100:22     192.168.1.1:54321
-tcp    LISTEN     0      128    0.0.0.0:80           0.0.0.0:*"""
-
-        mock_execute = mocker.patch.object(network, "execute_with_fallback")
+tcp    LISTEN     0      128    0.0.0.0:80           0.0.0.0:*""",
+                ["192.168.1.100", "Total connections: 2"],
+                id="local",
+            ),
+            pytest.param(
+                "remote.host",
+                """Netid  State      Recv-Q Send-Q Local Address:Port   Peer Address:Port
+tcp    ESTAB      0      0      10.0.0.5:443         10.0.0.1:12345""",
+                ["10.0.0.5"],
+                id="remote",
+            ),
+        ],
+    )
+    async def test_get_network_connections_success(self, mock_execute, host, mock_output, expected_content):
+        """Test getting network connections with success."""
         mock_execute.return_value = (0, mock_output, "")
 
-        result = await network.get_network_connections()
+        result = await network.get_network_connections(host=host)
 
         assert isinstance(result, str)
         assert "Active Network Connections" in result
-        assert "192.168.1.100" in result
-        assert "Total connections: 2" in result
+        for content in expected_content:
+            assert content in result
 
-    async def test_get_network_connections_remote(self, mocker):
-        """Test getting network connections remotely."""
-        mock_output = """Netid  State      Recv-Q Send-Q Local Address:Port   Peer Address:Port
-tcp    ESTAB      0      0      10.0.0.5:443         10.0.0.1:12345"""
-
-        mock_execute = mocker.patch.object(network, "execute_with_fallback")
-        mock_execute.return_value = (0, mock_output, "")
-
-        result = await network.get_network_connections(host="remote.host")
-
-        assert isinstance(result, str)
-        assert "Active Network Connections" in result
-        assert "10.0.0.5" in result
-
-    async def test_get_network_connections_command_fails(self, mocker):
-        """Test getting network connections when command fails."""
-        mock_execute = mocker.patch.object(network, "execute_with_fallback")
-        mock_execute.return_value = (1, "", "Command not found")
+    @pytest.mark.parametrize(
+        ("return_value",),
+        [
+            pytest.param((1, "", "Command not found"), id="command_fails"),
+            pytest.param((0, "", ""), id="empty_output"),
+        ],
+    )
+    async def test_get_network_connections_failure(self, mock_execute, return_value):
+        """Test getting network connections when command fails or returns empty."""
+        mock_execute.return_value = return_value
 
         result = await network.get_network_connections()
 
         assert isinstance(result, str)
         assert "Error" in result or "Neither ss nor netstat" in result
 
-    async def test_get_network_connections_error(self, mocker):
+    async def test_get_network_connections_error(self, mock_execute):
         """Test getting network connections with general error."""
-        mock_execute = mocker.patch.object(network, "execute_with_fallback")
         mock_execute.side_effect = Exception("Network error")
 
         result = await network.get_network_connections()
@@ -135,62 +141,59 @@ tcp    ESTAB      0      0      10.0.0.5:443         10.0.0.1:12345"""
         assert "Error getting network connections" in result
         assert "Network error" in result
 
-    async def test_get_network_connections_empty_output(self, mocker):
-        """Test getting network connections with empty output."""
-        mock_execute = mocker.patch.object(network, "execute_with_fallback")
-        mock_execute.return_value = (0, "", "")
-
-        result = await network.get_network_connections()
-
-        assert "Error" in result or "Neither" in result
-
 
 class TestGetListeningPorts:
     """Test get_listening_ports function."""
 
-    async def test_get_listening_ports_success(self, mocker):
-        """Test getting listening ports with success."""
-        mock_output = """Netid  State      Recv-Q Send-Q Local Address:Port   Peer Address:Port
+    @pytest.mark.parametrize(
+        ("host", "mock_output", "expected_content"),
+        [
+            pytest.param(
+                None,
+                """Netid  State      Recv-Q Send-Q Local Address:Port   Peer Address:Port
 tcp    LISTEN     0      128    0.0.0.0:80           0.0.0.0:*
-udp    UNCONN     0      0      0.0.0.0:53           0.0.0.0:*"""
-
-        mock_execute = mocker.patch.object(network, "execute_with_fallback")
+udp    UNCONN     0      0      0.0.0.0:53           0.0.0.0:*""",
+                ["0.0.0.0:80", "Total listening ports: 2"],
+                id="local",
+            ),
+            pytest.param(
+                "remote.host",
+                """Netid  State      Recv-Q Send-Q Local Address:Port   Peer Address:Port
+tcp    LISTEN     0      128    0.0.0.0:22           0.0.0.0:*""",
+                ["0.0.0.0:22"],
+                id="remote",
+            ),
+        ],
+    )
+    async def test_get_listening_ports_success(self, mock_execute, host, mock_output, expected_content):
+        """Test getting listening ports with success."""
         mock_execute.return_value = (0, mock_output, "")
 
-        result = await network.get_listening_ports()
+        result = await network.get_listening_ports(host=host)
 
         assert isinstance(result, str)
         assert "Listening Ports" in result
-        assert "0.0.0.0:80" in result
-        assert "Total listening ports: 2" in result
+        for content in expected_content:
+            assert content in result
 
-    async def test_get_listening_ports_remote(self, mocker):
-        """Test getting listening ports remotely."""
-        mock_output = """Netid  State      Recv-Q Send-Q Local Address:Port   Peer Address:Port
-tcp    LISTEN     0      128    0.0.0.0:22           0.0.0.0:*"""
-
-        mock_execute = mocker.patch.object(network, "execute_with_fallback")
-        mock_execute.return_value = (0, mock_output, "")
-
-        result = await network.get_listening_ports(host="remote.host")
-
-        assert isinstance(result, str)
-        assert "Listening Ports" in result
-        assert "0.0.0.0:22" in result
-
-    async def test_get_listening_ports_command_fails(self, mocker):
-        """Test getting listening ports when command fails."""
-        mock_execute = mocker.patch.object(network, "execute_with_fallback")
-        mock_execute.return_value = (1, "", "Command not found")
+    @pytest.mark.parametrize(
+        ("return_value",),
+        [
+            pytest.param((1, "", "Command not found"), id="command_fails"),
+            pytest.param((0, "", ""), id="empty_output"),
+        ],
+    )
+    async def test_get_listening_ports_failure(self, mock_execute, return_value):
+        """Test getting listening ports when command fails or returns empty."""
+        mock_execute.return_value = return_value
 
         result = await network.get_listening_ports()
 
         assert isinstance(result, str)
         assert "Error" in result or "Neither ss nor netstat" in result
 
-    async def test_get_listening_ports_error(self, mocker):
+    async def test_get_listening_ports_error(self, mock_execute):
         """Test getting listening ports with general error."""
-        mock_execute = mocker.patch.object(network, "execute_with_fallback")
         mock_execute.side_effect = Exception("Network error")
 
         result = await network.get_listening_ports()
@@ -198,12 +201,3 @@ tcp    LISTEN     0      128    0.0.0.0:22           0.0.0.0:*"""
         assert isinstance(result, str)
         assert "Error getting listening ports" in result
         assert "Network error" in result
-
-    async def test_get_listening_ports_empty_output(self, mocker):
-        """Test getting listening ports with empty output."""
-        mock_execute = mocker.patch.object(network, "execute_with_fallback")
-        mock_execute.return_value = (0, "", "")
-
-        result = await network.get_listening_ports()
-
-        assert "Error" in result or "Neither" in result


### PR DESCRIPTION
Apply the same parameterization pattern from TestGetNetworkInterfaces to TestGetNetworkConnections and TestGetListeningPorts:

- Reuse module-level mock_execute fixture instead of inline patches
- Combine local/remote success tests into parameterized test
- Combine command_fails/empty_output failure tests into parameterized test
- Keep exception tests separate (different assertion pattern)

Reduces test methods from 10 to 6 while maintaining full coverage.