### PR TITLE
refactor(commands): add type-safe registry lookup helpers

### DIFF
--- a/src/linux_mcp_server/commands.py
+++ b/src/linux_mcp_server/commands.py
@@ -148,6 +148,42 @@ def get_command(name: str) -> CommandEntry:
     return COMMANDS[name]
 
 
+def get_command_spec(key: str) -> CommandSpec:
+    """Get and validate a CommandSpec from the COMMANDS registry.
+
+    Args:
+        key: The command key to look up.
+
+    Returns:
+        The validated CommandSpec.
+
+    Raises:
+        TypeError: If the retrieved command is not a CommandSpec.
+    """
+    cmd = COMMANDS[key]
+    if not isinstance(cmd, CommandSpec):
+        raise TypeError(f"Expected CommandSpec for '{key}', got {type(cmd).__name__}")
+    return cmd
+
+
+def get_command_group(key: str) -> CommandGroup:
+    """Get and validate a CommandGroup from the COMMANDS registry.
+
+    Args:
+        key: The command group key to look up.
+
+    Returns:
+        The validated CommandGroup.
+
+    Raises:
+        TypeError: If the retrieved command is not a CommandGroup.
+    """
+    group = COMMANDS[key]
+    if not isinstance(group, CommandGroup):
+        raise TypeError(f"Expected CommandGroup for '{key}', got {type(group).__name__}")
+    return group
+
+
 def substitute_command_args(args: list[str], **kwargs) -> list[str]:
     """Substitute placeholder values in command arguments.
 

--- a/src/linux_mcp_server/tools/logs.py
+++ b/src/linux_mcp_server/tools/logs.py
@@ -10,8 +10,7 @@ from pydantic import Field
 
 from linux_mcp_server.audit import log_tool_call
 from linux_mcp_server.commands import build_journal_command
-from linux_mcp_server.commands import COMMANDS
-from linux_mcp_server.commands import CommandSpec
+from linux_mcp_server.commands import get_command_spec
 from linux_mcp_server.commands import substitute_command_args
 from linux_mcp_server.config import CONFIG
 from linux_mcp_server.connection.ssh import execute_command
@@ -100,9 +99,7 @@ async def get_audit_logs(
             return f"Audit log file not found at {audit_log_path}. Audit logging may not be enabled."
 
         # Get command from registry and format with parameters
-        cmd = COMMANDS["audit_logs"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'audit_logs', got {type(cmd).__name__}")
+        cmd = get_command_spec("audit_logs")
         args = substitute_command_args(cmd.args, lines=lines)
 
         returncode, stdout, stderr = await execute_command(args, host=host)
@@ -193,9 +190,7 @@ async def read_log_file(  # noqa: C901
                 )  # nofmt
             log_path_str = log_path
 
-        cmd = COMMANDS["read_log_file"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'read_log_file', got {type(cmd).__name__}")
+        cmd = get_command_spec("read_log_file")
         args = substitute_command_args(cmd.args, lines=lines, log_path=log_path_str)
 
         returncode, stdout, stderr = await execute_command(args, host=host)

--- a/src/linux_mcp_server/tools/network.py
+++ b/src/linux_mcp_server/tools/network.py
@@ -3,9 +3,8 @@
 from mcp.types import ToolAnnotations
 
 from linux_mcp_server.audit import log_tool_call
-from linux_mcp_server.commands import CommandGroup
-from linux_mcp_server.commands import COMMANDS
-from linux_mcp_server.commands import CommandSpec
+from linux_mcp_server.commands import get_command_group
+from linux_mcp_server.commands import get_command_spec
 from linux_mcp_server.connection.ssh import execute_with_fallback
 from linux_mcp_server.formatters import format_listening_ports
 from linux_mcp_server.formatters import format_network_connections
@@ -34,9 +33,7 @@ async def get_network_interfaces(
     """
     try:
         # Get command group from registry
-        group = COMMANDS["network_interfaces"]
-        if not isinstance(group, CommandGroup):
-            raise TypeError(f"Expected CommandGroup for 'network_interfaces', got {type(group).__name__}")
+        group = get_command_group("network_interfaces")
 
         interfaces = {}
         stats = {}
@@ -83,9 +80,7 @@ async def get_network_connections(
     """
     try:
         # Get command from registry
-        cmd = COMMANDS["network_connections"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'network_connections', got {type(cmd).__name__}")
+        cmd = get_command_spec("network_connections")
 
         returncode, stdout, stderr = await execute_with_fallback(
             cmd.args,
@@ -116,9 +111,7 @@ async def get_listening_ports(
     """
     try:
         # Get command from registry
-        cmd = COMMANDS["listening_ports"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'listening_ports', got {type(cmd).__name__}")
+        cmd = get_command_spec("listening_ports")
 
         returncode, stdout, stderr = await execute_with_fallback(
             cmd.args,

--- a/src/linux_mcp_server/tools/processes.py
+++ b/src/linux_mcp_server/tools/processes.py
@@ -6,9 +6,8 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from linux_mcp_server.audit import log_tool_call
-from linux_mcp_server.commands import CommandGroup
-from linux_mcp_server.commands import COMMANDS
-from linux_mcp_server.commands import CommandSpec
+from linux_mcp_server.commands import get_command_group
+from linux_mcp_server.commands import get_command_spec
 from linux_mcp_server.commands import substitute_command_args
 from linux_mcp_server.connection.ssh import execute_command
 from linux_mcp_server.formatters import format_process_detail
@@ -33,9 +32,7 @@ async def list_processes(
 ) -> str:
     try:
         # Get command from registry
-        cmd = COMMANDS["list_processes"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'list_processes', got {type(cmd).__name__}")
+        cmd = get_command_spec("list_processes")
 
         returncode, stdout, _ = await execute_command(cmd.args, host=host)
 
@@ -69,9 +66,7 @@ async def get_process_info(
 
     try:
         # Get command group from registry
-        group = COMMANDS["process_info"]
-        if not isinstance(group, CommandGroup):
-            raise TypeError(f"Expected CommandGroup for 'process_info', got {type(group).__name__}")
+        group = get_command_group("process_info")
 
         # Get process details with ps
         ps_cmd = group.commands["ps_detail"]

--- a/src/linux_mcp_server/tools/services.py
+++ b/src/linux_mcp_server/tools/services.py
@@ -6,8 +6,7 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from linux_mcp_server.audit import log_tool_call
-from linux_mcp_server.commands import COMMANDS
-from linux_mcp_server.commands import CommandSpec
+from linux_mcp_server.commands import get_command_spec
 from linux_mcp_server.commands import substitute_command_args
 from linux_mcp_server.connection.ssh import execute_command
 from linux_mcp_server.formatters import format_service_logs
@@ -35,9 +34,7 @@ async def list_services(
     """
     try:
         # Get command from registry
-        cmd = COMMANDS["list_services"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'list_services', got {type(cmd).__name__}")
+        cmd = get_command_spec("list_services")
 
         returncode, stdout, stderr = await execute_command(cmd.args, host=host)
 
@@ -45,9 +42,7 @@ async def list_services(
             return f"Error listing services: {stderr}"
 
         # Get running services count
-        running_cmd = COMMANDS["running_services"]
-        if not isinstance(running_cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'running_services', got {type(running_cmd).__name__}")
+        running_cmd = get_command_spec("running_services")
 
         returncode_summary, stdout_summary, _ = await execute_command(
             running_cmd.args,
@@ -85,9 +80,7 @@ async def get_service_status(
             service_name = f"{service_name}.service"
 
         # Get command from registry and format with service name
-        cmd = COMMANDS["service_status"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'service_status', got {type(cmd).__name__}")
+        cmd = get_command_spec("service_status")
         args = substitute_command_args(cmd.args, service_name=service_name)
 
         _, stdout, stderr = await execute_command(args, host=host)
@@ -130,9 +123,7 @@ async def get_service_logs(
             service_name = f"{service_name}.service"
 
         # Get command from registry and format with parameters
-        cmd = COMMANDS["service_logs"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'service_logs', got {type(cmd).__name__}")
+        cmd = get_command_spec("service_logs")
         args = substitute_command_args(cmd.args, service_name=service_name, lines=lines)
 
         returncode, stdout, stderr = await execute_command(args, host=host)

--- a/src/linux_mcp_server/tools/storage.py
+++ b/src/linux_mcp_server/tools/storage.py
@@ -10,8 +10,7 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from linux_mcp_server.audit import log_tool_call
-from linux_mcp_server.commands import COMMANDS
-from linux_mcp_server.commands import CommandSpec
+from linux_mcp_server.commands import get_command_spec
 from linux_mcp_server.commands import substitute_command_args
 from linux_mcp_server.connection.ssh import execute_command
 from linux_mcp_server.formatters import format_block_devices
@@ -76,9 +75,7 @@ async def list_block_devices(
     """
     try:
         # Get command from registry
-        cmd = COMMANDS["list_block_devices"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'list_block_devices', got {type(cmd).__name__}")
+        cmd = get_command_spec("list_block_devices")
 
         returncode, stdout, _ = await execute_command(cmd.args, host=host)
 
@@ -125,9 +122,7 @@ async def list_directories(
 
     # Get the appropriate command for the order_by field
     cmd_name = DIRECTORY_COMMANDS[order_by]
-    cmd = COMMANDS[cmd_name]
-    if not isinstance(cmd, CommandSpec):
-        raise TypeError(f"Expected CommandSpec for 'list_directories', got {type(cmd).__name__}")
+    cmd = get_command_spec(cmd_name)
 
     # Substitute path into command args
     args = substitute_command_args(cmd.args, path=path)
@@ -195,9 +190,7 @@ async def list_files(
 
     # Get the appropriate command for the order_by field
     cmd_name = FILE_COMMANDS[order_by]
-    cmd = COMMANDS[cmd_name]
-    if not isinstance(cmd, CommandSpec):
-        raise TypeError(f"Expected CommandSpec for 'list_files', got {type(cmd).__name__}")
+    cmd = get_command_spec(cmd_name)
 
     # Substitute path into command args
     args = substitute_command_args(cmd.args, path=path)
@@ -253,9 +246,7 @@ async def read_file(
             raise ToolError(f"Path is not a file: {path}")
 
     # Get command from registry and substitute path
-    cmd = COMMANDS["read_file"]
-    if not isinstance(cmd, CommandSpec):
-        raise TypeError(f"Expected CommandSpec for 'read_file', got {type(cmd).__name__}")
+    cmd = get_command_spec("read_file")
     args = substitute_command_args(cmd.args, path=path)
 
     try:

--- a/src/linux_mcp_server/tools/system_info.py
+++ b/src/linux_mcp_server/tools/system_info.py
@@ -3,9 +3,8 @@
 from mcp.types import ToolAnnotations
 
 from linux_mcp_server.audit import log_tool_call
-from linux_mcp_server.commands import CommandGroup
-from linux_mcp_server.commands import COMMANDS
-from linux_mcp_server.commands import CommandSpec
+from linux_mcp_server.commands import get_command_group
+from linux_mcp_server.commands import get_command_spec
 from linux_mcp_server.connection.ssh import execute_command
 from linux_mcp_server.connection.ssh import execute_with_fallback
 from linux_mcp_server.formatters import format_cpu_info
@@ -36,9 +35,7 @@ async def get_system_information(
     """
     try:
         # Get command group from registry
-        group = COMMANDS["system_info"]
-        if not isinstance(group, CommandGroup):
-            raise TypeError(f"Expected CommandGroup for 'system_info', got {type(group).__name__}")
+        group = get_command_group("system_info")
 
         results = {}
 
@@ -69,9 +66,7 @@ async def get_cpu_information(
     """
     try:
         # Get command group from registry
-        group = COMMANDS["cpu_info"]
-        if not isinstance(group, CommandGroup):
-            raise TypeError(f"Expected CommandGroup for 'cpu_info', got {type(group).__name__}")
+        group = get_command_group("cpu_info")
 
         results = {}
 
@@ -102,9 +97,7 @@ async def get_memory_information(
     """
     try:
         # Get command group from registry
-        group = COMMANDS["memory_info"]
-        if not isinstance(group, CommandGroup):
-            raise TypeError(f"Expected CommandGroup for 'memory_info', got {type(group).__name__}")
+        group = get_command_group("memory_info")
 
         # Execute free command
         free_cmd = group.commands["free"]
@@ -134,9 +127,7 @@ async def get_disk_usage(
     """
     try:
         # Get command from registry
-        cmd = COMMANDS["disk_usage"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'disk_usage', got {type(cmd).__name__}")
+        cmd = get_command_spec("disk_usage")
 
         returncode, stdout, _ = await execute_with_fallback(
             cmd.args,
@@ -167,9 +158,7 @@ async def get_hardware_information(
     """
     try:
         # Get command group from registry
-        group = COMMANDS["hardware_info"]
-        if not isinstance(group, CommandGroup):
-            raise TypeError(f"Expected CommandGroup for 'hardware_info', got {type(group).__name__}")
+        group = get_command_group("hardware_info")
 
         results = {}
 


### PR DESCRIPTION
Add get_command_spec() and get_command_group() functions to centralize type validation when retrieving commands from the COMMANDS registry. This eliminates repeated 2-3 line isinstance checks across all tool modules.

- Add get_command_spec() for CommandSpec lookups
- Add get_command_group() for CommandGroup lookups
- Update all tool modules to use the new helpers
- Remove direct COMMANDS access and manual isinstance checks