### PR TITLE
Use get_command instead of accessing global dictionary

### DIFF
--- a/src/linux_mcp_server/commands.py
+++ b/src/linux_mcp_server/commands.py
@@ -143,9 +143,19 @@ def get_command(name: str) -> CommandEntry:
         The CommandSpec or CommandGroup for the given name.
 
     Raises:
-        KeyError: If the command name is not found in the registry.
+        TypeError: If the command name is not found in the registry or
+        if the entry is not a valid CommandSpec or CommandGroup.
     """
-    return COMMANDS[name]
+    try:
+        cmd = COMMANDS[name]
+
+        # Match both the CommandGroup and CommandSpec
+        if not isinstance(cmd, (CommandSpec, CommandGroup)):
+            raise TypeError(f"Expected CommandSpec or CommandGroup for '{name}', got {type(cmd).__name__}")
+    except KeyError as e:
+        raise TypeError(f"CommandSpec for '{name}' not found.") from e
+
+    return cmd
 
 
 def substitute_command_args(args: list[str], **kwargs) -> list[str]:

--- a/src/linux_mcp_server/tools/logs.py
+++ b/src/linux_mcp_server/tools/logs.py
@@ -10,8 +10,8 @@ from pydantic import Field
 
 from linux_mcp_server.audit import log_tool_call
 from linux_mcp_server.commands import build_journal_command
-from linux_mcp_server.commands import COMMANDS
 from linux_mcp_server.commands import CommandSpec
+from linux_mcp_server.commands import get_command
 from linux_mcp_server.commands import substitute_command_args
 from linux_mcp_server.config import CONFIG
 from linux_mcp_server.connection.ssh import execute_command
@@ -100,9 +100,7 @@ async def get_audit_logs(
             return f"Audit log file not found at {audit_log_path}. Audit logging may not be enabled."
 
         # Get command from registry and format with parameters
-        cmd = COMMANDS["audit_logs"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'audit_logs', got {type(cmd).__name__}")
+        cmd = t.cast(CommandSpec, get_command("audit_logs"))
         args = substitute_command_args(cmd.args, lines=lines)
 
         returncode, stdout, stderr = await execute_command(args, host=host)
@@ -193,9 +191,7 @@ async def read_log_file(  # noqa: C901
                 )  # nofmt
             log_path_str = log_path
 
-        cmd = COMMANDS["read_log_file"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'read_log_file', got {type(cmd).__name__}")
+        cmd = t.cast(CommandSpec, get_command("read_log_file"))
         args = substitute_command_args(cmd.args, lines=lines, log_path=log_path_str)
 
         returncode, stdout, stderr = await execute_command(args, host=host)

--- a/src/linux_mcp_server/tools/network.py
+++ b/src/linux_mcp_server/tools/network.py
@@ -1,11 +1,13 @@
 """Network diagnostic tools."""
 
+import typing as t
+
 from mcp.types import ToolAnnotations
 
 from linux_mcp_server.audit import log_tool_call
 from linux_mcp_server.commands import CommandGroup
-from linux_mcp_server.commands import COMMANDS
 from linux_mcp_server.commands import CommandSpec
+from linux_mcp_server.commands import get_command
 from linux_mcp_server.connection.ssh import execute_with_fallback
 from linux_mcp_server.formatters import format_listening_ports
 from linux_mcp_server.formatters import format_network_connections
@@ -34,9 +36,7 @@ async def get_network_interfaces(
     """
     try:
         # Get command group from registry
-        group = COMMANDS["network_interfaces"]
-        if not isinstance(group, CommandGroup):
-            raise TypeError(f"Expected CommandGroup for 'network_interfaces', got {type(group).__name__}")
+        group = t.cast(CommandGroup, get_command("network_interfaces"))
 
         interfaces = {}
         stats = {}
@@ -83,9 +83,7 @@ async def get_network_connections(
     """
     try:
         # Get command from registry
-        cmd = COMMANDS["network_connections"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'network_connections', got {type(cmd).__name__}")
+        cmd = t.cast(CommandSpec, get_command("network_connections"))
 
         returncode, stdout, stderr = await execute_with_fallback(
             cmd.args,
@@ -116,9 +114,7 @@ async def get_listening_ports(
     """
     try:
         # Get command from registry
-        cmd = COMMANDS["listening_ports"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'listening_ports', got {type(cmd).__name__}")
+        cmd = t.cast(CommandSpec, get_command("listening_ports"))
 
         returncode, stdout, stderr = await execute_with_fallback(
             cmd.args,

--- a/src/linux_mcp_server/tools/processes.py
+++ b/src/linux_mcp_server/tools/processes.py
@@ -7,8 +7,8 @@ from pydantic import Field
 
 from linux_mcp_server.audit import log_tool_call
 from linux_mcp_server.commands import CommandGroup
-from linux_mcp_server.commands import COMMANDS
 from linux_mcp_server.commands import CommandSpec
+from linux_mcp_server.commands import get_command
 from linux_mcp_server.commands import substitute_command_args
 from linux_mcp_server.connection.ssh import execute_command
 from linux_mcp_server.formatters import format_process_detail
@@ -33,9 +33,7 @@ async def list_processes(
 ) -> str:
     try:
         # Get command from registry
-        cmd = COMMANDS["list_processes"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'list_processes', got {type(cmd).__name__}")
+        cmd = t.cast(CommandSpec, get_command("list_processes"))
 
         returncode, stdout, _ = await execute_command(cmd.args, host=host)
 
@@ -69,9 +67,7 @@ async def get_process_info(
 
     try:
         # Get command group from registry
-        group = COMMANDS["process_info"]
-        if not isinstance(group, CommandGroup):
-            raise TypeError(f"Expected CommandGroup for 'process_info', got {type(group).__name__}")
+        group = t.cast(CommandGroup, get_command("process_info"))
 
         # Get process details with ps
         ps_cmd = group.commands["ps_detail"]

--- a/src/linux_mcp_server/tools/services.py
+++ b/src/linux_mcp_server/tools/services.py
@@ -6,8 +6,8 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from linux_mcp_server.audit import log_tool_call
-from linux_mcp_server.commands import COMMANDS
 from linux_mcp_server.commands import CommandSpec
+from linux_mcp_server.commands import get_command
 from linux_mcp_server.commands import substitute_command_args
 from linux_mcp_server.connection.ssh import execute_command
 from linux_mcp_server.formatters import format_service_logs
@@ -35,9 +35,7 @@ async def list_services(
     """
     try:
         # Get command from registry
-        cmd = COMMANDS["list_services"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'list_services', got {type(cmd).__name__}")
+        cmd = t.cast(CommandSpec, get_command("list_services"))
 
         returncode, stdout, stderr = await execute_command(cmd.args, host=host)
 
@@ -45,9 +43,7 @@ async def list_services(
             return f"Error listing services: {stderr}"
 
         # Get running services count
-        running_cmd = COMMANDS["running_services"]
-        if not isinstance(running_cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'running_services', got {type(running_cmd).__name__}")
+        running_cmd = t.cast(CommandSpec, get_command("running_services"))
 
         returncode_summary, stdout_summary, _ = await execute_command(
             running_cmd.args,
@@ -85,9 +81,7 @@ async def get_service_status(
             service_name = f"{service_name}.service"
 
         # Get command from registry and format with service name
-        cmd = COMMANDS["service_status"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'service_status', got {type(cmd).__name__}")
+        cmd = t.cast(CommandSpec, get_command("service_status"))
         args = substitute_command_args(cmd.args, service_name=service_name)
 
         _, stdout, stderr = await execute_command(args, host=host)
@@ -130,9 +124,7 @@ async def get_service_logs(
             service_name = f"{service_name}.service"
 
         # Get command from registry and format with parameters
-        cmd = COMMANDS["service_logs"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'service_logs', got {type(cmd).__name__}")
+        cmd = t.cast(CommandSpec, get_command("service_logs"))
         args = substitute_command_args(cmd.args, service_name=service_name, lines=lines)
 
         returncode, stdout, stderr = await execute_command(args, host=host)

--- a/src/linux_mcp_server/tools/storage.py
+++ b/src/linux_mcp_server/tools/storage.py
@@ -10,8 +10,8 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from linux_mcp_server.audit import log_tool_call
-from linux_mcp_server.commands import COMMANDS
 from linux_mcp_server.commands import CommandSpec
+from linux_mcp_server.commands import get_command
 from linux_mcp_server.commands import substitute_command_args
 from linux_mcp_server.connection.ssh import execute_command
 from linux_mcp_server.formatters import format_block_devices
@@ -76,9 +76,7 @@ async def list_block_devices(
     """
     try:
         # Get command from registry
-        cmd = COMMANDS["list_block_devices"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'list_block_devices', got {type(cmd).__name__}")
+        cmd = t.cast(CommandSpec, get_command("list_block_devices"))
 
         returncode, stdout, _ = await execute_command(cmd.args, host=host)
 
@@ -124,10 +122,7 @@ async def list_directories(
     path = _validate_path(path)
 
     # Get the appropriate command for the order_by field
-    cmd_name = DIRECTORY_COMMANDS[order_by]
-    cmd = COMMANDS[cmd_name]
-    if not isinstance(cmd, CommandSpec):
-        raise TypeError(f"Expected CommandSpec for 'list_directories', got {type(cmd).__name__}")
+    cmd = t.cast(CommandSpec, get_command(DIRECTORY_COMMANDS[order_by]))
 
     # Substitute path into command args
     args = substitute_command_args(cmd.args, path=path)
@@ -194,10 +189,7 @@ async def list_files(
         path = _validate_path(path)
 
     # Get the appropriate command for the order_by field
-    cmd_name = FILE_COMMANDS[order_by]
-    cmd = COMMANDS[cmd_name]
-    if not isinstance(cmd, CommandSpec):
-        raise TypeError(f"Expected CommandSpec for 'list_files', got {type(cmd).__name__}")
+    cmd = t.cast(CommandSpec, get_command(FILE_COMMANDS[order_by]))
 
     # Substitute path into command args
     args = substitute_command_args(cmd.args, path=path)
@@ -253,9 +245,7 @@ async def read_file(
             raise ToolError(f"Path is not a file: {path}")
 
     # Get command from registry and substitute path
-    cmd = COMMANDS["read_file"]
-    if not isinstance(cmd, CommandSpec):
-        raise TypeError(f"Expected CommandSpec for 'read_file', got {type(cmd).__name__}")
+    cmd = t.cast(CommandSpec, get_command("read_file"))
     args = substitute_command_args(cmd.args, path=path)
 
     try:

--- a/src/linux_mcp_server/tools/system_info.py
+++ b/src/linux_mcp_server/tools/system_info.py
@@ -1,11 +1,13 @@
 """System information tools."""
 
+import typing as t
+
 from mcp.types import ToolAnnotations
 
 from linux_mcp_server.audit import log_tool_call
 from linux_mcp_server.commands import CommandGroup
-from linux_mcp_server.commands import COMMANDS
 from linux_mcp_server.commands import CommandSpec
+from linux_mcp_server.commands import get_command
 from linux_mcp_server.connection.ssh import execute_command
 from linux_mcp_server.connection.ssh import execute_with_fallback
 from linux_mcp_server.formatters import format_cpu_info
@@ -36,10 +38,7 @@ async def get_system_information(
     """
     try:
         # Get command group from registry
-        group = COMMANDS["system_info"]
-        if not isinstance(group, CommandGroup):
-            raise TypeError(f"Expected CommandGroup for 'system_info', got {type(group).__name__}")
-
+        group = t.cast(CommandGroup, get_command("system_info"))
         results = {}
 
         # Execute all commands in the group
@@ -69,10 +68,7 @@ async def get_cpu_information(
     """
     try:
         # Get command group from registry
-        group = COMMANDS["cpu_info"]
-        if not isinstance(group, CommandGroup):
-            raise TypeError(f"Expected CommandGroup for 'cpu_info', got {type(group).__name__}")
-
+        group = t.cast(CommandGroup, get_command("cpu_info"))
         results = {}
 
         # Execute all commands in the group
@@ -102,9 +98,7 @@ async def get_memory_information(
     """
     try:
         # Get command group from registry
-        group = COMMANDS["memory_info"]
-        if not isinstance(group, CommandGroup):
-            raise TypeError(f"Expected CommandGroup for 'memory_info', got {type(group).__name__}")
+        group = t.cast(CommandGroup, get_command("memory_info"))
 
         # Execute free command
         free_cmd = group.commands["free"]
@@ -134,9 +128,7 @@ async def get_disk_usage(
     """
     try:
         # Get command from registry
-        cmd = COMMANDS["disk_usage"]
-        if not isinstance(cmd, CommandSpec):
-            raise TypeError(f"Expected CommandSpec for 'disk_usage', got {type(cmd).__name__}")
+        cmd = t.cast(CommandSpec, get_command("disk_usage"))
 
         returncode, stdout, _ = await execute_with_fallback(
             cmd.args,
@@ -167,10 +159,7 @@ async def get_hardware_information(
     """
     try:
         # Get command group from registry
-        group = COMMANDS["hardware_info"]
-        if not isinstance(group, CommandGroup):
-            raise TypeError(f"Expected CommandGroup for 'hardware_info', got {type(group).__name__}")
-
+        group = t.cast(CommandGroup, get_command("hardware_info"))
         results = {}
 
         # Execute all commands in the group


### PR DESCRIPTION
All tools were accessing the global dictionary of `COMMANDS` directly, and some of them had condition handling in case the specified command was not in the proper state, but many of them didn't. This patch moves the conditional handling to be inside `get_command` and refactor the tools to use it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified command resolution across logging, network, processes, services, storage, and system-info tools to use a centralized registry accessor with consistent validation and error handling; no public APIs or function signatures changed.
* **Tests**
  * Added tests validating the centralized lookup behavior and its TypeError/error conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->