### PR TITLE
Refactor tools and CommandSpec running

### DIFF
--- a/src/linux_mcp_server/tools/network.py
+++ b/src/linux_mcp_server/tools/network.py
@@ -4,7 +4,6 @@ from mcp.types import ToolAnnotations
 
 from linux_mcp_server.audit import log_tool_call
 from linux_mcp_server.commands import get_command
-from linux_mcp_server.connection.ssh import execute_with_fallback
 from linux_mcp_server.formatters import format_listening_ports
 from linux_mcp_server.formatters import format_network_connections
 from linux_mcp_server.formatters import format_network_interfaces
@@ -36,22 +35,14 @@ async def get_network_interfaces(
 
         # Get brief interface info
         brief_cmd = get_command("network_interfaces", "brief")
-        returncode, stdout, _ = await execute_with_fallback(
-            brief_cmd.args,
-            fallback=brief_cmd.fallback,
-            host=host,
-        )
+        returncode, stdout, _ = await brief_cmd.run(host=host)
 
         if returncode == 0 and stdout:
             interfaces = parse_ip_brief(stdout)
 
         # Get network statistics from /proc/net/dev
         stats_cmd = get_command("network_interfaces", "stats")
-        returncode, stdout, _ = await execute_with_fallback(
-            stats_cmd.args,
-            fallback=stats_cmd.fallback,
-            host=host,
-        )
+        returncode, stdout, _ = await stats_cmd.run(host=host)
 
         if returncode == 0 and stdout:
             stats = parse_proc_net_dev(stdout)
@@ -77,11 +68,7 @@ async def get_network_connections(
     try:
         cmd = get_command("network_connections")
 
-        returncode, stdout, stderr = await execute_with_fallback(
-            cmd.args,
-            fallback=cmd.fallback,
-            host=host,
-        )
+        returncode, stdout, stderr = await cmd.run(host=host)
 
         if returncode == 0 and stdout:
             connections = parse_ss_connections(stdout)
@@ -107,11 +94,7 @@ async def get_listening_ports(
     try:
         cmd = get_command("listening_ports")
 
-        returncode, stdout, stderr = await execute_with_fallback(
-            cmd.args,
-            fallback=cmd.fallback,
-            host=host,
-        )
+        returncode, stdout, stderr = await cmd.run(host=host)
 
         if returncode == 0 and stdout:
             ports = parse_ss_listening(stdout)

--- a/src/linux_mcp_server/tools/processes.py
+++ b/src/linux_mcp_server/tools/processes.py
@@ -7,8 +7,6 @@ from pydantic import Field
 
 from linux_mcp_server.audit import log_tool_call
 from linux_mcp_server.commands import get_command
-from linux_mcp_server.commands import substitute_command_args
-from linux_mcp_server.connection.ssh import execute_command
 from linux_mcp_server.formatters import format_process_detail
 from linux_mcp_server.formatters import format_process_list
 from linux_mcp_server.parsers import parse_proc_status
@@ -31,7 +29,7 @@ async def list_processes(
 ) -> str:
     try:
         cmd = get_command("list_processes")
-        returncode, stdout, _ = await execute_command(cmd.args, host=host)
+        returncode, stdout, _ = await cmd.run(host=host)
 
         if returncode == 0 and stdout:
             processes = parse_ps_output(stdout)
@@ -64,9 +62,7 @@ async def get_process_info(
     try:
         # Get process details with ps
         ps_cmd = get_command("process_info", "ps_detail")
-        args = substitute_command_args(ps_cmd.args, pid=validated_pid)
-
-        returncode, stdout, _ = await execute_command(args, host=host)
+        returncode, stdout, _ = await ps_cmd.run(host=host, pid=validated_pid)
 
         if returncode != 0:
             return f"Process with PID {validated_pid} does not exist."
@@ -77,9 +73,7 @@ async def get_process_info(
         # Try to get more details from /proc
         proc_status = None
         status_cmd = get_command("process_info", "proc_status")
-        status_args = substitute_command_args(status_cmd.args, pid=validated_pid)
-
-        status_code, status_stdout, _ = await execute_command(status_args, host=host)
+        status_code, status_stdout, _ = await status_cmd.run(host=host, pid=validated_pid)
 
         if status_code == 0 and status_stdout:
             proc_status = parse_proc_status(status_stdout)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,26 +49,26 @@ async def adecorated_fail():
 
 
 @pytest.fixture
-def mock_execute_command_for(mocker):
-    """Factory fixture for mocking execute_command in any module.
+def mock_execute_with_fallback_for(mocker):
+    """Factory fixture for mocking execute_with_fallback in any module.
 
-    Returns a callable that creates mocks for execute_command in the specified module.
+    Returns a callable that creates mocks for execute_with_fallback in the specified module.
     Uses autospec=True to verify arguments match the real function signature.
 
     Usage:
         @pytest.fixture
-        def mock_execute_command(mock_execute_command_for):
-            return mock_execute_command_for("linux_mcp_server.tools.mymodule")
+        def mock_execute_with_fallback(mock_execute_with_fallback_for):
+            return mock_execute_with_fallback_for("linux_mcp_server.commands")
 
-        async def test_something(mock_execute_command):
-            mock_execute_command.return_value = (0, "output", "")
+        async def test_something(mock_execute_with_fallback):
+            mock_execute_with_fallback.return_value = (0, "output", "")
             # ... test code ...
-            mock_execute_command.assert_called_once()
+            mock_execute_with_fallback.assert_called_once()
     """
 
     def _mock(module: str):
         return mocker.patch(
-            f"{module}.execute_command",
+            f"{module}.execute_with_fallback",
             autospec=True,
         )
 

--- a/tests/tools/test_network.py
+++ b/tests/tools/test_network.py
@@ -2,13 +2,11 @@
 
 import pytest
 
-from linux_mcp_server.tools import network
-
 
 @pytest.fixture
-def mock_execute(mocker):
+def mock_execute(mock_execute_with_fallback_for):
     """Mock execute_with_fallback for network module."""
-    return mocker.patch.object(network, "execute_with_fallback", autospec=True)
+    return mock_execute_with_fallback_for("linux_mcp_server.commands")
 
 
 class TestGetNetworkInterfaces:


### PR DESCRIPTION
Add a method on CommandSpec (run) that performs the execute_command and fallback handling. Update the tools to call the CommandSpec.run method instead of execute_command directly.

The new usage of this method changes the tool code.

## Before
```python
cmd = get_command("read_log_file")
args = substitute_command_args(cmd.args, lines=lines, log_path=log_path_str)

returncode, stdout, stderr = await execute_command(args, host=host)
```

## After
```python
cmd = get_command("read_log_file")
returncode, stdout, stderr = await cmd.run(host=host, lines=lines, log_path=log_path_str)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized a unified run-based command execution across system tools, simplifying remote/local command handling and removing legacy helpers.

* **New Features**
  * Added support for optional command flags to enable more flexible log and service queries (e.g., unit, priority, since).

* **Tests**
  * Updated and consolidated fixtures and mocks to validate the unified execution path and remote/local behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->