### PR TITLE
Remove --no-pager option from lsblk

### DIFF
--- a/src/linux_mcp_server/commands.py
+++ b/src/linux_mcp_server/commands.py
@@ -124,7 +124,7 @@ COMMANDS: Mapping[str, CommandGroup] = MappingProxyType(
         # === Storage ===
         "list_block_devices": CommandGroup(
             commands={
-                "default": CommandSpec(args=("lsblk", "-o", "NAME,SIZE,TYPE,MOUNTPOINT,FSTYPE,MODEL", "--no-pager")),
+                "default": CommandSpec(args=("lsblk", "-o", "NAME,SIZE,TYPE,MOUNTPOINT,FSTYPE,MODEL")),
             }
         ),
         "disk_usage": CommandGroup(


### PR DESCRIPTION
--no-pager is not a valid parameter for lsblk, which causes an error when executing for remote and local devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified the output behavior of the block devices listing command to allow paginated display, enabling better handling of large result sets in terminal environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->