### PR TITLE
Add functional testing to CI/CD

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 3 * * *'
 
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   tf-functional-tests:
     name: Functional Tests (Testing Farm)


### PR DESCRIPTION
Add functional tests for MCP server to the CI workflow.

It is scheduled to run every day at 03:00 UTC