### PR TITLE
ci: add GitHub Actions workflow for documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,15 +26,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v6.0.1
 
       - name: Install Python
-        uses: actions/setup-python@v6.0.0
+        uses: actions/setup-python@v6.1.0
         with:
           python-version-file: pyproject.toml
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.1.0
+        uses: astral-sh/setup-uv@v7.1.6
         with:
           enable-cache: true
           prune-cache: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,9 +132,11 @@ output = "coverage/coverage.xml"
 [tool.gha-update]
 tag-only = [
     "actions/checkout",
+    "actions/deploy-pages",
     "actions/download-artifact",
     "actions/setup-python",
     "actions/upload-artifact",
+    "actions/upload-pages-artifact",
     "astral-sh/setup-uv",
     "codecov/codecov-action",
     "pypa/gh-action-pypi-publish",


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to build and deploy documentation to GitHub Pages
- Workflow triggers on push to main when docs-related files change
- Supports manual dispatch for on-demand builds

**Depends on:** #133

## Changes

- **.github/workflows/docs.yml**: New workflow with build and deploy jobs

## Workflow Details

**Triggers:**
- Push to `main` branch (filtered to relevant paths)
- Manual `workflow_dispatch`

**Path filters:**
- `docs/**`
- `src/**`
- `mkdocs.yml`
- `pyproject.toml`

**Jobs:**
1. **build**: Install deps, build docs with `--strict`, upload artifact
2. **deploy**: Deploy to GitHub Pages environment

## GitHub Pages Setup

After merging, enable GitHub Pages in repository settings:
1. Go to **Settings** → **Pages**
2. Under "Build and deployment", set Source to **GitHub Actions**
3. The workflow will deploy automatically on next push to main

## Test plan

- [ ] Workflow syntax is valid (GitHub will validate on push)
- [ ] Build job succeeds after PR #133 is merged
- [ ] Deploy job publishes to GitHub Pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Automated documentation build and deployment to GitHub Pages is enabled for changes on main, keeping docs up to date.
  * Documentation builds run in strict mode (treating warnings as errors) and can be triggered manually for immediate deployment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->