### PR TITLE
fix(types): add type annotations for **kwargs parameters

### DIFF
--- a/src/linux_mcp_server/audit.py
+++ b/src/linux_mcp_server/audit.py
@@ -88,7 +88,7 @@ def sanitize_parameters(params: dict[str, t.Any]) -> dict[str, t.Any]:
 
 
 @contextmanager
-def AuditContext(**extra_fields):
+def AuditContext(**extra_fields: t.Any) -> t.Generator[logging.LoggerAdapter, None, None]:
     """
     Context manager for adding extra fields to all log records.
 
@@ -97,10 +97,10 @@ def AuditContext(**extra_fields):
             logger.info("Starting operation")
 
     Args:
-        **extra_fields: Additional fields to add to log records
+        **extra_fields: Additional fields to add to log records.
 
     Yields:
-        Logger with extra fields
+        logging.LoggerAdapter: Logger adapter with extra fields attached.
     """
     logger = logging.getLogger()
 

--- a/src/linux_mcp_server/commands.py
+++ b/src/linux_mcp_server/commands.py
@@ -31,7 +31,7 @@ class CommandSpec(BaseModel):
     fallback: tuple[str, ...] | None = None
     optional_flags: Mapping[str, tuple[str, ...]] | None = None
 
-    async def run(self, host: str | None = None, **kwargs) -> tuple[int, str, str]:
+    async def run(self, host: str | None = None, **kwargs: object) -> tuple[int, str, str]:
         """Run the command with optional fallback.
 
         Args:
@@ -287,7 +287,7 @@ def get_command(name: str, subcommand: str = "default") -> CommandSpec:
         raise KeyError(f"Subcommand '{subcommand}' not found for '{name}'. Available: {available}") from e
 
 
-def substitute_command_args(args: Sequence[str], **kwargs) -> tuple[str, ...]:
+def substitute_command_args(args: Sequence[str], **kwargs: object) -> tuple[str, ...]:
     """Substitute placeholder values in command arguments.
 
     Args:


### PR DESCRIPTION
## Summary

Add missing type annotations that were causing griffe warnings, which prevented `--strict` mode from working in mkdocs builds.

## Changes

**audit.py:**
- `AuditContext(**extra_fields: t.Any)` - added type for kwargs
- `-> t.Generator[logging.LoggerAdapter, None, None]` - added return type
- Updated docstring `Yields:` section with type

**commands.py:**
- `run(**kwargs: object)` - added type for kwargs
- `substitute_command_args(**kwargs: object)` - added type for kwargs

## Test plan

- [x] `make types` passes (pyright)
- [x] `make test` passes (381 tests)
- [x] `make docs` passes with `--strict` mode