### PR TITLE
docs: remove non-existent verification command from install docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,7 @@ A Model Context Protocol (MCP) server for read-only Linux system administration,
 
 1. Install via pip
 ```bash
-pip install --user linux-mcp-server      # Install the MCP server
-~/.local/bin/linux-mcp-server --help     # Verify installation
+pip install --user linux-mcp-server
 ```
 
 2. [Configure your favorite MCP client](clients.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -44,12 +44,6 @@ The Linux MCP Server can be installed using pip, uv, or containers. Choose the m
 pip install --user linux-mcp-server
 ```
 
-**Verify installation:**
-
-```bash
-~/.local/bin/linux-mcp-server --help
-```
-
 ??? failure "Command not found?"
 
     The `~/.local/bin` directory may not be in your PATH.


### PR DESCRIPTION
## Summary

- Remove `~/.local/bin/linux-mcp-server --help` verification command from `docs/index.md` and `docs/install.md`
- This path doesn't exist after `pip install --user` installation

## Test plan

- [ ] Verify docs build: `mkdocs build`
- [ ] Review rendered docs locally: `mkdocs serve`