### PR TITLE
docs(tools): expand docstrings for logs tools

### DIFF
--- a/src/linux_mcp_server/tools/logs.py
+++ b/src/linux_mcp_server/tools/logs.py
@@ -46,8 +46,10 @@ async def get_journal_logs(
     lines: t.Annotated[int, Field(description="Number of log lines to retrieve. Default: 100")] = 100,
     host: Host | None = None,
 ) -> str:
-    """
-    Get systemd journal logs.
+    """Get systemd journal logs.
+
+    Retrieves entries from the systemd journal with optional filtering by unit,
+    priority level, and time range. Returns timestamped log messages.
     """
     try:
         # Validate lines parameter (accepts floats from LLMs)
@@ -81,8 +83,11 @@ async def get_audit_logs(
     lines: t.Annotated[int, Field(description="Number of log lines to retrieve.")] = 100,
     host: Host | None = None,
 ) -> str:
-    """
-    Get audit logs.
+    """Get Linux audit logs.
+
+    Retrieves entries from /var/log/audit/audit.log containing security-relevant
+    events such as authentication, authorization, and system call auditing.
+    Requires root privileges to read.
     """
     # Validate lines parameter (accepts floats from LLMs)
     lines, _ = validate_line_count(lines, default=100)
@@ -124,8 +129,10 @@ async def read_log_file(  # noqa: C901
     lines: t.Annotated[int, Field(description="Number of lines to retrieve from the end.")] = 100,
     host: Host | None = None,
 ) -> str:
-    """
-    Read a specific log file.
+    """Read a specific log file.
+
+    Retrieves the last N lines from a log file. The file path must be in the
+    allowed list configured via LINUX_MCP_ALLOWED_LOG_PATHS environment variable.
     """
     try:
         # Validate lines parameter (accepts floats from LLMs)


### PR DESCRIPTION
## Summary

- Expand docstrings in `logs.py` tool functions with meaningful descriptions

## Why

This enables mkdocstrings to display better documentation in the generated API docs.

## Functions Updated

| Function | Docstring Description |
|----------|----------------------|
| `get_journal_logs()` | Retrieves entries from the systemd journal with optional filtering by unit, priority level, and time range. Returns timestamped log messages |
| `get_audit_logs()` | Retrieves entries from /var/log/audit/audit.log containing security-relevant events such as authentication, authorization, and system call auditing. Requires root privileges |
| `read_log_file()` | Retrieves the last N lines from a log file. The file path must be in the allowed list configured via LINUX_MCP_ALLOWED_LOG_PATHS environment variable |