### PR TITLE
RSPEED-2283: feat(logs): use journalctl for audit logs

### DIFF
--- a/src/linux_mcp_server/commands.py
+++ b/src/linux_mcp_server/commands.py
@@ -121,13 +121,9 @@ COMMANDS: Mapping[str, CommandGroup] = MappingProxyType(
                         "unit": ("--unit", "{unit}"),
                         "priority": ("--priority", "{priority}"),
                         "since": ("--since", "{since}"),
+                        "transport": ("_TRANSPORT={transport}",),
                     },
                 ),
-            }
-        ),
-        "audit_logs": CommandGroup(
-            commands={
-                "default": CommandSpec(args=("tail", "-n", "{lines}", "/var/log/audit/audit.log")),
             }
         ),
         "read_log_file": CommandGroup(

--- a/src/linux_mcp_server/formatters.py
+++ b/src/linux_mcp_server/formatters.py
@@ -364,8 +364,8 @@ def format_audit_logs(stdout: str, lines_count: int) -> str:
     """Format audit logs output.
 
     Args:
-        stdout: Raw output from tail on audit.log.
-        lines_count: Number of log lines.
+        stdout: Raw output from journalctl with transport="audit" filter.
+        lines_count: Number of log lines requested.
 
     Returns:
         Formatted string representation.


### PR DESCRIPTION
## Summary

- Replace direct `/var/log/audit/audit.log` access with `journalctl _TRANSPORT=audit` filter
- Refactor log tools to share a common `_get_journal_logs()` helper, reducing code duplication
- Remove the now-unused `audit_logs` command from the command registry

## What is being done?

The `get_audit_logs` tool now uses `journalctl` with the `_TRANSPORT=audit` filter instead of reading directly from `/var/log/audit/audit.log`.

## Why is it being done?

The previous implementation required root privileges to read `/var/log/audit/audit.log`, which is restricted to root-only access on Linux systems. Since this MCP server will never run as root, the old approach would always fail with "Permission denied".

The systemd journal captures audit events and makes them accessible to users with appropriate group membership (typically `wheel`, `adm`, or `systemd-journal` groups). Using `journalctl _TRANSPORT=audit` allows non-root users to access audit logs without requiring elevated privileges.

## Testing

- All existing tests updated and passing
- `make verify` passes (lint, type check, tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional transport parameter for journal log filtering.

* **Bug Fixes**
  * Audit log retrieval now uses journalctl for more reliable, consistent results across systems.

* **Chores**
  * Removed the legacy audit_logs command group.

* **Tests**
  * Updated tests to validate journalctl-based audit log behavior and transport/host handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->