### PR TITLE
read_file rejects reading binary files

### DIFF
--- a/src/linux_mcp_server/tools/storage.py
+++ b/src/linux_mcp_server/tools/storage.py
@@ -232,21 +232,23 @@ async def read_file(
     Retrieves the full contents of a text file. The path must be absolute
     and the file must exist. Binary files may not display correctly.
     """
-    # For local execution, validate path
-    if not host:
-        path = _validate_path(path)
 
+    # Validate path
+    path = _validate_path(path)
+
+    if not host:
+        # For local execution, check early if file exists
         if not os.path.isfile(path):
             raise ToolError(f"Path is not a file: {path}")
 
     cmd = get_command("read_file")
 
     try:
-        returncode, stdout, stderr = await cmd.run(host=host, path=path)
+        returncode, stdout, stderr = await cmd.run_bytes(host=host, path=path)
 
         if returncode != 0:
             raise ToolError(f"Error running command: command failed with return code {returncode}: {stderr}")
 
-        return stdout
+        return stdout.decode("utf-8")
     except Exception as e:
         raise ToolError(f"Error reading file: {str(e)}") from e


### PR DESCRIPTION
Add encoding parameter to remote execution functions to return either bytes or str. CommandSpec gains `run_bytes` method for raw output. The `read_file` tool now uses this and rejects binary files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving raw binary output from command execution.
  * Extended command execution with flexible encoding options (UTF-8 by default).

* **Bug Fixes**
  * Improved file reading with consistent encoding handling and enhanced path validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->