### PR TITLE
Add missing `args` in Goose configuration

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -364,6 +364,7 @@ If you prefer editing config files directly, add to `~/.config/goose/config.yaml
         timeout: 30
         bundled: null
         available_tools: []
+        args: []
     ```
 
 === "Container (Podman)"


### PR DESCRIPTION
Based on some testing, @mairin found out that we were missing a key `args` in our config for pip/uv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Goose YAML configuration documentation for pip/uv installation to clarify the empty arguments list setting for the linux-mcp-server extension when using container/podman setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->