### PR TITLE
refactor(logging): migrate from stdlib logging to loguru

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.10"
 dependencies = [
     "asyncssh[bcrypt] >= 2.22.0",
     "fastmcp >=2.14.3, <3",
+    "loguru >= 0.7.3",
     "pydantic-settings >= 2.12.0",
     "pydantic >= 2.12.5",
 ]

--- a/src/linux_mcp_server/__main__.py
+++ b/src/linux_mcp_server/__main__.py
@@ -1,7 +1,8 @@
 """Main entry point for the Linux MCP Server."""
 
-import logging
 import sys
+
+from loguru import logger
 
 from linux_mcp_server import __version__
 from linux_mcp_server.logging_config import setup_logging
@@ -12,7 +13,6 @@ def cli():
     """Console script entry point for the Linux MCP Server."""
     setup_logging()
 
-    logger = logging.getLogger("linux-mcp-server")
     logger.info(f"Running Linux MCP Server {__version__}. Press Ctrl+C, Enter to stop the server.")
 
     try:

--- a/src/linux_mcp_server/logging_config.py
+++ b/src/linux_mcp_server/logging_config.py
@@ -1,20 +1,22 @@
 """Centralized logging configuration for Linux MCP Server.
 
-Simplified logging setup with standard Python logging infrastructure.
-Supports structured logging with extra fields for audit and diagnostic purposes.
+Simplified logging setup using loguru for structured logging with
+automatic JSON serialization and log rotation.
 """
 
-import json
-import logging
-import logging.handlers
+import sys
+import typing as t
+
+from loguru import logger
 
 from linux_mcp_server.config import CONFIG
 
 
-def get_log_level() -> int:
-    """Get the log level from environment variable (defaults to INFO)."""
-    level_name = CONFIG.log_level
-    return getattr(logging, level_name, logging.INFO)
+def _format_extra_fields(extra: dict[str, t.Any]) -> str:
+    """Format extra fields as pipe-separated key=value pairs for human-readable logs."""
+    if not extra:
+        return ""
+    return " | ".join(f"{k}={v}" for k, v in extra.items())
 
 
 def get_retention_days() -> int:
@@ -25,144 +27,48 @@ def get_retention_days() -> int:
         return 10
 
 
-class StructuredFormatter(logging.Formatter):
-    """
-    Structured log formatter supporting extra fields.
-
-    Format: TIMESTAMP | LEVEL | MODULE | MESSAGE | key=value ...
-    Extra fields added to LogRecord are appended as key=value pairs.
-    """
-
-    STANDARD_FIELDS = {
-        "name",
-        "msg",
-        "args",
-        "created",
-        "filename",
-        "funcName",
-        "levelname",
-        "levelno",
-        "lineno",
-        "module",
-        "msecs",
-        "message",
-        "pathname",
-        "process",
-        "processName",
-        "relativeCreated",
-        "thread",
-        "threadName",
-        "exc_info",
-        "exc_text",
-        "stack_info",
-        "asctime",
-        "taskName",
-    }
-
-    def format(self, record: logging.LogRecord) -> str:
-        """Format a log record with extra fields."""
-        # Base message
-        base_msg = super().format(record)
-
-        # Append extra fields as key=value pairs
-        extra_fields = [f"{k}={v}" for k, v in record.__dict__.items() if k not in self.STANDARD_FIELDS]
-
-        return f"{base_msg} | {' | '.join(extra_fields)}" if extra_fields else base_msg
-
-
-class JSONFormatter(logging.Formatter):
-    """JSON log formatter for machine-readable logs."""
-
-    EXCLUDE_FIELDS = {
-        "args",
-        "exc_text",
-        "exc_info",
-        "stack_info",
-        "filename",
-        "funcName",
-        "lineno",
-        "module",
-        "msecs",
-        "pathname",
-        "process",
-        "processName",
-        "relativeCreated",
-        "thread",
-        "threadName",
-        "taskName",
-    }
-
-    def format(self, record: logging.LogRecord) -> str:
-        """Format a log record as JSON."""
-        log_data = {
-            "timestamp": self.formatTime(record, self.datefmt),
-            "level": record.levelname,
-            "logger": record.name,
-            "message": record.getMessage(),
-        }
-
-        # Add exception info if present
-        if record.exc_info:
-            log_data["exception"] = self.formatException(record.exc_info)
-
-        # Add extra fields
-        for key, value in record.__dict__.items():
-            if (
-                key not in self.EXCLUDE_FIELDS
-                and key not in log_data
-                and key not in {"name", "msg", "levelname", "levelno", "created"}
-            ):
-                log_data[key] = value
-
-        return json.dumps(log_data)
-
-
-def setup_logging():
-    """Set up logging with structured formatters and rotation."""
+def setup_logging() -> None:
+    """Configure loguru with text file, JSON file, and console sinks."""
     log_dir = CONFIG.log_dir
     log_dir.mkdir(parents=True, exist_ok=True)
-    log_level = get_log_level()
     retention_days = get_retention_days()
 
-    # Configure root logger
-    root_logger = logging.getLogger()
-    root_logger.setLevel(log_level)
-    root_logger.handlers.clear()  # Remove existing handlers
+    # Remove default handler
+    logger.remove()
 
-    # Human-readable text log
-    text_handler = logging.handlers.TimedRotatingFileHandler(
-        filename=log_dir / "server.log",
-        when="midnight",
-        interval=1,
-        backupCount=retention_days,
+    # Console sink (human-readable)
+    logger.add(
+        sys.stderr,
+        format="{time:YYYY-MM-DD HH:mm:ss} | {level} | {name} | {message}",
+        level=CONFIG.log_level,
+    )
+
+    def format_with_extra(record: t.Any) -> str:
+        """Custom format function that appends extra fields as key=value pairs."""
+        base = "{time:YYYY-MM-DD HH:mm:ss} | {level} | {name} | {message}"
+        extra_str = _format_extra_fields(record["extra"])
+        if extra_str:
+            return base + " | " + extra_str + "\n"
+        return base + "\n"
+
+    # Text file sink (human-readable with rotation)
+    logger.add(
+        log_dir / "server.log",
+        format=format_with_extra,
+        level=CONFIG.log_level,
+        rotation="1 day",
+        retention=f"{retention_days} days",
         encoding="utf-8",
     )
-    text_handler.setLevel(log_level)
-    text_handler.setFormatter(
-        StructuredFormatter("%(asctime)s | %(levelname)s | %(name)s | %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
-    )
-    text_handler.suffix = "%Y-%m-%d"
-    root_logger.addHandler(text_handler)
 
-    # JSON log
-    json_handler = logging.handlers.TimedRotatingFileHandler(
-        filename=log_dir / "server.json",
-        when="midnight",
-        interval=1,
-        backupCount=retention_days,
+    # JSON file sink (machine-readable)
+    logger.add(
+        log_dir / "server.json",
+        serialize=True,
+        level=CONFIG.log_level,
+        rotation="1 day",
+        retention=f"{retention_days} days",
         encoding="utf-8",
     )
-    json_handler.setLevel(log_level)
-    json_handler.setFormatter(JSONFormatter(datefmt="%Y-%m-%dT%H:%M:%S"))
-    json_handler.suffix = "%Y-%m-%d"
-    root_logger.addHandler(json_handler)
 
-    # Console handler for development
-    console_handler = logging.StreamHandler()
-    console_handler.setLevel(log_level)
-    console_handler.setFormatter(
-        StructuredFormatter("%(asctime)s | %(levelname)s | %(name)s | %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
-    )
-    root_logger.addHandler(console_handler)
-
-    root_logger.info(f"Logging initialized: {log_dir}")
+    logger.info(f"Logging initialized: {log_dir}")

--- a/src/linux_mcp_server/server.py
+++ b/src/linux_mcp_server/server.py
@@ -1,11 +1,6 @@
 """Core MCP server for Linux diagnostics using FastMCP."""
 
-import logging
-
 from fastmcp import FastMCP
-
-
-logger = logging.getLogger("linux-mcp-server")
 
 
 # Initialize FastMCP server

--- a/tests/connection/ssh/test_host_key_verification.py
+++ b/tests/connection/ssh/test_host_key_verification.py
@@ -53,7 +53,7 @@ async def test_known_hosts_configuration(
     ssh_manager,
     mock_asyncssh_connect,
     tmp_path,
-    caplog,
+    loguru_caplog,
     verify_host_keys,
     use_custom_path,
     expect_none,
@@ -66,8 +66,7 @@ async def test_known_hosts_configuration(
     mocker.patch("linux_mcp_server.connection.ssh.CONFIG.known_hosts_path", custom_path)
     mocker.patch("pathlib.Path.home", return_value=tmp_path)
 
-    with caplog.at_level("WARNING"):
-        await ssh_manager.get_connection("testhost")
+    await ssh_manager.get_connection("testhost")
 
     if expect_none:
         assert mock_asyncssh_connect["known_hosts"] is None
@@ -77,7 +76,7 @@ async def test_known_hosts_configuration(
         assert mock_asyncssh_connect["known_hosts"] == str(tmp_path / ".ssh" / "known_hosts")
 
     if expect_warning:
-        assert "host key verification disabled" in caplog.text.lower()
-        assert "mitm" in caplog.text.lower()
+        assert "host key verification disabled" in loguru_caplog.text.lower()
+        assert "mitm" in loguru_caplog.text.lower()
     else:
-        assert "mitm" not in caplog.text.lower()
+        assert "mitm" not in loguru_caplog.text.lower()

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,8 +1,8 @@
 """Tests for audit logging utilities."""
 
-import logging
-
 import pytest
+
+from loguru import logger
 
 from linux_mcp_server.audit import AuditContext
 from linux_mcp_server.audit import Event
@@ -24,17 +24,17 @@ class TestSanitizeParameters:
 
     def test_sanitize_normal_parameters(self):
         """Test sanitizing normal parameters."""
-        params = {"host": "server1.com", "lines": 50, "service_name": "nginx"}
+        params = {"host": "testhost", "lines": 50, "service_name": "nginx"}
         result = sanitize_parameters(params)
         assert result == params
 
     def test_sanitize_password_field(self):
         """Test that password fields are sanitized."""
-        params = {"username": "admin", "password": "secret123", "host": "server1.com"}
+        params = {"username": "admin", "password": "secret123", "host": "testhost"}
         result = sanitize_parameters(params)
         assert result["username"] == "admin"
         assert result["password"] == "***REDACTED***"
-        assert result["host"] == "server1.com"
+        assert result["host"] == "testhost"
 
     def test_sanitize_api_key_field(self):
         """Test that API key fields are sanitized."""
@@ -70,41 +70,21 @@ class TestAuditContext:
 
     def test_context_creates_logger(self):
         """Test that context creates a logger with extra fields."""
-        with AuditContext(tool="test_tool", host="server1.com") as logger:
-            # AuditContext returns a LoggerAdapter, not a Logger
-            assert isinstance(logger, (logging.Logger, logging.LoggerAdapter))
+        with AuditContext(tool="test_tool", host="testhost") as log:
+            # AuditContext yields the loguru logger
+            assert log is logger
 
-    def test_context_fields_in_log(self):
+    def test_context_fields_in_log(self, loguru_caplog):
         """Test that context fields appear in log records."""
-        # Create a custom handler to capture records
-        test_handler = logging.Handler()
-        test_handler.setLevel(logging.INFO)
-        records = []
+        with AuditContext(tool="test_tool", host="testhost") as log:
+            log.info("Test message")
 
-        class RecordCapture(logging.Handler):
-            def emit(self, record):
-                records.append(record)
-
-        capture = RecordCapture()
-        capture.setLevel(logging.INFO)
-
-        root_logger = logging.getLogger()
-        root_logger.addHandler(capture)
-        root_logger.setLevel(logging.INFO)
-
-        try:
-            with AuditContext(tool="test_tool", host="server1.com") as logger:
-                logger.info("Test message")
-
-            # Check that log record has the extra fields
-            assert len(records) >= 1
-            record = [r for r in records if "Test message" in r.getMessage()][0]
-            assert hasattr(record, "tool")
-            assert record.tool == "test_tool"
-            assert hasattr(record, "host")
-            assert record.host == "server1.com"
-        finally:
-            root_logger.removeHandler(capture)
+        # Check that log record has the extra fields
+        filtered = [r for r in loguru_caplog.records if "Test message" in r["message"]]
+        assert filtered, "expected log record with 'Test message'"
+        record = filtered[0]
+        assert record["extra"]["tool"] == "test_tool"
+        assert record["extra"]["host"] == "testhost"
 
 
 class TestLogToolCall:
@@ -114,155 +94,139 @@ class TestLogToolCall:
         ("params", "mode"),
         (
             ({}, ExecutionMode.LOCAL),
-            ({"host": "server1.com", "username": "admin"}, ExecutionMode.REMOTE),
+            ({"host": "testhost", "username": "admin"}, ExecutionMode.REMOTE),
         ),
     )
-    def test_log_tool_call(self, caplog, decorated, params, mode):
+    def test_log_tool_call(self, loguru_caplog, decorated, params, mode):
         """Test logging a sync tool call."""
-        with caplog.at_level(logging.INFO):
-            decorated(**params)
+        decorated(**params)
 
-        record = caplog.records[0]
+        assert Event.TOOL_CALL in loguru_caplog.text
+        assert "list_services" in loguru_caplog.text
 
-        assert Event.TOOL_CALL in caplog.text
-        assert "list_services" in caplog.text
-        assert caplog.records
-        assert getattr(record, "execution_mode") == mode
+        # Check execution mode in extra
+        filtered = [r for r in loguru_caplog.records if Event.TOOL_CALL in r["message"]]
+        assert filtered, "expected TOOL_CALL log record"
+        assert filtered[0]["extra"]["execution_mode"] == mode
 
     @pytest.mark.parametrize(
         ("params", "mode"),
         (
             ({}, ExecutionMode.LOCAL),
-            ({"host": "server1.com", "username": "admin"}, ExecutionMode.REMOTE),
+            ({"host": "testhost", "username": "admin"}, ExecutionMode.REMOTE),
         ),
     )
-    async def test_log_tool_call_async(self, caplog, adecorated, params, mode):
+    async def test_log_tool_call_async(self, loguru_caplog, adecorated, params, mode):
         """Test logging an async call."""
-        with caplog.at_level(logging.INFO):
-            await adecorated(**params)
+        await adecorated(**params)
 
-        record = caplog.records[0]
+        assert Event.TOOL_CALL in loguru_caplog.text
+        assert "list_services" in loguru_caplog.text
 
-        assert Event.TOOL_CALL in caplog.text
-        assert "list_services" in caplog.text
-        assert caplog.records
-        assert getattr(record, "execution_mode", None) == mode
+        # Check execution mode in extra
+        filtered = [r for r in loguru_caplog.records if Event.TOOL_CALL in r["message"]]
+        assert filtered, "expected TOOL_CALL log record"
+        assert filtered[0]["extra"]["execution_mode"] == mode
 
     @pytest.mark.parametrize("sensitive_field", SENSITIVE_FIELDS)
-    def test_log_tool_call_sanitizes_parameters(self, caplog, decorated, sensitive_field):
+    def test_log_tool_call_sanitizes_parameters(self, loguru_caplog, decorated, sensitive_field):
         """Test that tool call logging sanitizes sensitive parameters."""
         secret_value = "secret123"
         params = {sensitive_field: secret_value, "username": "admin"}
-        with caplog.at_level(logging.INFO):
-            decorated(**params)
+        decorated(**params)
 
-        assert Event.TOOL_CALL in caplog.text
-        assert secret_value not in caplog.text
-        assert "REDACTED" in caplog.text
+        assert Event.TOOL_CALL in loguru_caplog.text
+        assert secret_value not in loguru_caplog.text
+        assert "REDACTED" in loguru_caplog.text
 
     @pytest.mark.parametrize("sensitive_field", SENSITIVE_FIELDS)
-    async def test_log_tool_call_async_sanitizes_parameters(self, caplog, adecorated, sensitive_field):
+    async def test_log_tool_call_async_sanitizes_parameters(self, loguru_caplog, adecorated, sensitive_field):
         """Test that tool call logging sanitizes sensitive parameters."""
         secret_value = "secret123"
         params = {sensitive_field: secret_value, "username": "admin"}
-        with caplog.at_level(logging.INFO):
-            await adecorated(**params)
+        await adecorated(**params)
 
-        assert Event.TOOL_CALL in caplog.text
-        assert secret_value not in caplog.text
-        assert "REDACTED" in caplog.text
+        assert Event.TOOL_CALL in loguru_caplog.text
+        assert secret_value not in loguru_caplog.text
+        assert "REDACTED" in loguru_caplog.text
 
-    def test_log_tool_call_failure(self, caplog, decorated_fail):
-        with caplog.at_level(logging.INFO), pytest.raises(ValueError, match="Raised intentionally"):
+    def test_log_tool_call_failure(self, loguru_caplog, decorated_fail):
+        """Test logging a tool call that raises an exception."""
+        with pytest.raises(ValueError, match="Raised intentionally"):
             decorated_fail()
 
-        assert "error: Raised intentionally" in caplog.text
+        assert "error: Raised intentionally" in loguru_caplog.text
 
-    async def test_log_tool_call_async_failure(self, caplog, adecorated_fail):
-        with caplog.at_level(logging.INFO):
-            with pytest.raises(ValueError, match="Raised intentionally"):
-                await adecorated_fail()
+    async def test_log_tool_call_async_failure(self, loguru_caplog, adecorated_fail):
+        """Test logging an async tool call that raises an exception."""
+        with pytest.raises(ValueError, match="Raised intentionally"):
+            await adecorated_fail()
 
-        assert "error: Raised intentionally" in caplog.text
+        assert "error: Raised intentionally" in loguru_caplog.text
 
 
 class TestLogSSHConnect:
     """Test SSH connection logging."""
 
-    def test_log_ssh_connect_success_info(self, caplog):
+    def test_log_ssh_connect_success_info(self, loguru_caplog):
         """Test logging successful SSH connection at INFO level."""
-        with caplog.at_level(logging.INFO):
-            log_ssh_connect("server1.com", status=Status.success, reused=False)
+        log_ssh_connect("testhost", status=Status.success, reused=False)
 
-        assert Event.SSH_CONNECT in caplog.text
-        assert "server1.com" in caplog.text
-        # Check the log record attributes
-        assert len(caplog.records) >= 1
-        record = caplog.records[-1]
-        assert hasattr(record, "status")
-        assert record.status == "success"
-        # At INFO level, reused might not be in the record if logger is not at DEBUG
-        # (depends on implementation)
+        assert Event.SSH_CONNECT in loguru_caplog.text
+        assert "testhost" in loguru_caplog.text
 
-    def test_log_ssh_connect_success_debug(self, caplog):
-        """Test logging successful SSH connection at DEBUG level shows more details."""
-        # Set the root logger to DEBUG level so our check in log_ssh_connect works
-        logging.getLogger().setLevel(logging.DEBUG)
+        record = loguru_caplog.records[-1]
+        assert record["extra"]["status"] == "success"
 
-        with caplog.at_level(logging.DEBUG):
-            log_ssh_connect("server1.com", status=Status.success, reused=True, key_path="/home/user/.ssh/id_rsa")
+    def test_log_ssh_connect_with_extra_details(self, loguru_caplog):
+        """Test logging successful SSH connection includes reused and key_path in extra."""
+        log_ssh_connect(
+            "testhost",
+            status=Status.success,
+            reused=True,
+            key_path="/home/user/.ssh/id_rsa",
+        )
 
-        assert Event.SSH_CONNECT in caplog.text
-        assert "server1.com" in caplog.text
-        # Check the log record attributes
-        assert len(caplog.records) >= 1
-        record = caplog.records[-1]
-        assert hasattr(record, "status")
-        assert record.status == "success"
-        # At DEBUG level, SHOULD show reused status and key path
-        assert hasattr(record, "reused")
-        assert record.reused
-        assert hasattr(record, "key")
-        assert ".ssh/id_rsa" in record.key
+        assert Event.SSH_CONNECT in loguru_caplog.text
+        assert "testhost" in loguru_caplog.text
 
-    def test_log_ssh_connect_failure(self, caplog):
+        record = loguru_caplog.records[-1]
+        assert record["extra"]["status"] == "success"
+        assert record["extra"]["reused"] == "True"
+        assert ".ssh/id_rsa" in record["extra"]["key"]
+
+    def test_log_ssh_connect_failure(self, loguru_caplog):
         """Test logging failed SSH connection."""
-        with caplog.at_level(logging.WARNING):
-            log_ssh_connect("server1.com", status="failed", error="Permission denied")
+        log_ssh_connect("testhost", status=Status.failed, error="Permission denied")
 
-        assert Event.SSH_CONNECT in caplog.text or Event.SSH_AUTH_FAILED in caplog.text
-        assert "server1.com" in caplog.text
-        assert "Permission denied" in caplog.text
+        assert Event.SSH_AUTH_FAILED in loguru_caplog.text
+        assert "testhost" in loguru_caplog.text
+        assert "Permission denied" in loguru_caplog.text
 
 
 class TestLogSSHCommand:
     """Test SSH command execution logging."""
 
-    def test_log_ssh_command_info(self, caplog):
+    def test_log_ssh_command_info(self, loguru_caplog):
         """Test logging SSH command at INFO level."""
-        with caplog.at_level(logging.INFO):
-            log_ssh_command("systemctl status nginx", "server1.com", exit_code=0, duration=0.15)
+        log_ssh_command("systemctl status nginx", "testhost", exit_code=0, duration=0.15)
 
-        assert Event.REMOTE_EXEC in caplog.text
-        assert "systemctl status nginx" in caplog.text
-        assert "server1.com" in caplog.text
-        assert "exit_code=0" in caplog.text
-        # At INFO level, duration may or may not be shown
-        # depending on implementation
+        assert Event.REMOTE_EXEC in loguru_caplog.text
+        assert "systemctl status nginx" in loguru_caplog.text
+        assert "testhost" in loguru_caplog.text
+        assert "exit_code=0" in loguru_caplog.text
 
-    def test_log_ssh_command_debug(self, caplog):
-        """Test logging SSH command at DEBUG level shows duration."""
-        with caplog.at_level(logging.DEBUG):
-            log_ssh_command("ls -la", "server1.com", exit_code=0, duration=0.05)
+    def test_log_ssh_command_includes_duration(self, loguru_caplog):
+        """Test logging SSH command includes duration when provided."""
+        log_ssh_command("ls -la", "testhost", exit_code=0, duration=0.05)
 
-        assert Event.REMOTE_EXEC in caplog.text
-        assert "ls -la" in caplog.text
-        assert "duration" in caplog.text.lower()
+        assert Event.REMOTE_EXEC in loguru_caplog.text
+        assert "ls -la" in loguru_caplog.text
+        assert "duration" in loguru_caplog.text.lower()
 
-    def test_log_ssh_command_error(self, caplog):
+    def test_log_ssh_command_error(self, loguru_caplog):
         """Test logging SSH command with non-zero exit code."""
-        with caplog.at_level(logging.INFO):
-            log_ssh_command("systemctl status missing", "server1.com", exit_code=3, duration=0.1)
+        log_ssh_command("systemctl status missing", "testhost", exit_code=3, duration=0.1)
 
-        assert Event.REMOTE_EXEC in caplog.text
-        assert "exit_code=3" in caplog.text
+        assert Event.REMOTE_EXEC in loguru_caplog.text
+        assert "exit_code=3" in loguru_caplog.text

--- a/uv.lock
+++ b/uv.lock
@@ -1079,6 +1079,7 @@ source = { editable = "." }
 dependencies = [
     { name = "asyncssh", extra = ["bcrypt"] },
     { name = "fastmcp" },
+    { name = "loguru" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
@@ -1123,6 +1124,7 @@ requires-dist = [
     { name = "asyncssh", extras = ["bcrypt"], specifier = ">=2.22.0" },
     { name = "fastmcp", specifier = ">=2.14.3,<3" },
     { name = "gssapi", marker = "extra == 'gssapi'", specifier = ">=1.2.0" },
+    { name = "loguru", specifier = ">=0.7.3" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
 ]
@@ -1155,6 +1157,19 @@ test = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-mock" },
     { name = "pytest-randomly" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
 ]
 
 [[package]]
@@ -2744,6 +2759,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Replaces stdlib `logging` with [loguru](https://github.com/Delgan/loguru) for simpler structured logging.

**Why**: JSON output, log rotation, and structured fields now require ~60% less code. Custom `StructuredFormatter`/`JSONFormatter` classes deleted entirely.

### Changes

- Add `loguru>=0.7.3` dependency
- Convert `extra={}` dict pattern → `.bind()` chaining
- Replace custom `AuditContext` LoggerAdapter with `logger.contextualize()`
- Add `loguru_caplog` pytest fixture for test log capture

```
11 files changed, 437 insertions(+), 559 deletions(-)
```

## Test plan

- [x] All tests pass
- [x] `make verify` clean (ruff, pyright, coverage)