### PR TITLE
Use the simple string descriptions for parameters

### DIFF
--- a/src/linux_mcp_server/tools/logs.py
+++ b/src/linux_mcp_server/tools/logs.py
@@ -29,20 +29,14 @@ from linux_mcp_server.utils.validation import validate_line_count
 @log_tool_call
 @disallow_local_execution_in_containers
 async def get_journal_logs(
-    unit: t.Annotated[
-        str | None, Field(description="Filter by systemd unit name or pattern (e.g., 'nginx.service', 'ssh*')")
-    ] = None,
+    unit: t.Annotated[str | None, "Filter by systemd unit name or pattern (e.g., 'nginx.service', 'ssh*')"] = None,
     priority: t.Annotated[
         str | None,
-        Field(
-            description="Filter by priority. Possible values: priority level (0-7), syslog level name ('emerg' to 'debug'), or range (e.g., 'err..info')"
-        ),
+        "Filter by priority. Possible values: priority level (0-7), syslog level name ('emerg' to 'debug'), or range (e.g., 'err..info')",
     ] = None,
     since: t.Annotated[
         str | None,
-        Field(
-            description="Filter entries since specified time. Date/time filter (format: 'YYYY-MM-DD HH:MM:SS', 'today', 'yesterday', 'now', or relative like '-1h')"
-        ),
+        "Filter entries since specified time. Date/time filter (format: 'YYYY-MM-DD HH:MM:SS', 'today', 'yesterday', 'now', or relative like '-1h')",
     ] = None,
     lines: t.Annotated[int, Field(description="Number of log lines to retrieve. Default: 100")] = 100,
     host: Host = None,
@@ -81,7 +75,7 @@ async def get_journal_logs(
 @log_tool_call
 @disallow_local_execution_in_containers
 async def get_audit_logs(
-    lines: t.Annotated[int, Field(description="Number of log lines to retrieve.")] = 100,
+    lines: t.Annotated[int, "Number of log lines to retrieve."] = 100,
     host: Host = None,
 ) -> str:
     """Get Linux audit logs.
@@ -126,8 +120,8 @@ async def get_audit_logs(
 @log_tool_call
 @disallow_local_execution_in_containers
 async def read_log_file(  # noqa: C901
-    log_path: t.Annotated[str, Field(description="Path to the log file")],
-    lines: t.Annotated[int, Field(description="Number of lines to retrieve from the end.")] = 100,
+    log_path: t.Annotated[str, "Path to the log file"],
+    lines: t.Annotated[int, "Number of lines to retrieve from the end."] = 100,
     host: Host = None,
 ) -> str:
     """Read a specific log file.

--- a/src/linux_mcp_server/tools/services.py
+++ b/src/linux_mcp_server/tools/services.py
@@ -3,7 +3,6 @@
 import typing as t
 
 from mcp.types import ToolAnnotations
-from pydantic import Field
 
 from linux_mcp_server.audit import log_tool_call
 from linux_mcp_server.commands import get_command
@@ -63,7 +62,7 @@ async def list_services(
 @log_tool_call
 @disallow_local_execution_in_containers
 async def get_service_status(
-    service_name: t.Annotated[str, Field(description="Name of the service")],
+    service_name: t.Annotated[str, "Name of the service"],
     host: Host = None,
 ) -> str:
     """Get status of a specific systemd service.
@@ -101,8 +100,8 @@ async def get_service_status(
 @log_tool_call
 @disallow_local_execution_in_containers
 async def get_service_logs(
-    service_name: t.Annotated[str, Field(description="Name of the service")],
-    lines: t.Annotated[int, Field(description="Number of log lines to retrieve.")] = 50,
+    service_name: t.Annotated[str, "Name of the service"],
+    lines: t.Annotated[int, "Number of log lines to retrieve."] = 50,
     host: Host = None,
 ) -> str:
     """Get recent logs for a specific systemd service.

--- a/src/linux_mcp_server/tools/storage.py
+++ b/src/linux_mcp_server/tools/storage.py
@@ -96,13 +96,9 @@ async def list_block_devices(
 @log_tool_call
 @disallow_local_execution_in_containers
 async def list_directories(
-    path: t.Annotated[str, Field(description="The directory path to analyze")],
-    order_by: t.Annotated[
-        OrderBy, Field(description="Sort order - 'size', 'name', or 'modified' (default: 'name')")
-    ] = OrderBy.NAME,
-    sort: t.Annotated[
-        SortBy, Field(description="Sort direction - 'ascending' or 'descending' (default: 'ascending')")
-    ] = SortBy.ASCENDING,
+    path: t.Annotated[str, "The directory path to analyze"],
+    order_by: t.Annotated[OrderBy, "Sort order - 'size', 'name', or 'modified' (default: 'name')"] = OrderBy.NAME,
+    sort: t.Annotated[SortBy, "Sort direction - 'ascending' or 'descending' (default: 'ascending')"] = SortBy.ASCENDING,
     top_n: t.Annotated[
         int | None,
         Field(
@@ -159,13 +155,9 @@ async def list_directories(
 @log_tool_call
 @disallow_local_execution_in_containers
 async def list_files(
-    path: t.Annotated[str, Field(description="The path to analyze")],
-    order_by: t.Annotated[
-        OrderBy, Field(description="Sort order - 'size', 'name', or 'modified' (default: 'name')")
-    ] = OrderBy.NAME,
-    sort: t.Annotated[
-        SortBy, Field(description="Sort direction - 'ascending' or 'descending' (default: 'ascending')")
-    ] = SortBy.ASCENDING,
+    path: t.Annotated[str, "The path to analyze"],
+    order_by: t.Annotated[OrderBy, "Sort order - 'size', 'name', or 'modified' (default: 'name')"] = OrderBy.NAME,
+    sort: t.Annotated[SortBy, "Sort direction - 'ascending' or 'descending' (default: 'ascending')"] = SortBy.ASCENDING,
     top_n: t.Annotated[
         int | None,
         Field(
@@ -224,7 +216,7 @@ async def list_files(
 @log_tool_call
 @disallow_local_execution_in_containers
 async def read_file(
-    path: t.Annotated[str, Field(description="The file path to read")],
+    path: t.Annotated[str, "The file path to read"],
     host: Host = None,
 ) -> str:
     """Read the contents of a file.


### PR DESCRIPTION
Now that we are using a new enough version of FastMCP, we can use [simple string descriptions](https://gofastmcp.com/servers/tools#simple-string-descriptions). Not all of the parameters use that because some can use validation fields available to the `Field` object. I'll make that change in a follow up PR which also removes use of all the `validate_*` functions.