### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_installation.yaml
+++ b/.github/workflows/ci_installation.yaml
@@ -15,6 +15,9 @@ on:
       - 'src/linux_mcp_server/**'
       - 'scripts/verify_installation.sh'
 
+permissions:
+  contents: read
+
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
   FORCE_COLOR: 1


### PR DESCRIPTION
Potential fix for [https://github.com/rhel-lightspeed/linux-mcp-server/security/code-scanning/12](https://github.com/rhel-lightspeed/linux-mcp-server/security/code-scanning/12)

To fix the problem, explicitly declare the minimal required `permissions` for the workflow or the specific job so that the `GITHUB_TOKEN` does not inherit potentially broad default permissions. This workflow only checks out code and runs a shell script; it does not interact with issues, PRs, or perform writes to the repo, so `contents: read` is sufficient.

The best way to fix this without changing functionality is to add a `permissions` block at the workflow root level (top-level, alongside `on:` and `env:`). This will apply to all jobs in the workflow, including `installation_qa`, and constrain the token appropriately. Concretely, in `.github/workflows/ci_installation.yaml`, between the `on:` block (lines 3–16) and the `env:` block (line 18), insert:

```yaml
permissions:
  contents: read
```

No imports or other definitions are needed because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
