### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/rhel-lightspeed/linux-mcp-server/security/code-scanning/5](https://github.com/rhel-lightspeed/linux-mcp-server/security/code-scanning/5)

In general, the fix is to explicitly set a `permissions:` block so that the `GITHUB_TOKEN` granted to this workflow (and/or specific jobs) follows the principle of least privilege instead of inheriting potentially broad repository defaults.

The best way to fix this specific workflow, without changing functionality, is:

- Add a root-level `permissions:` block (at the same indentation as `on:` and `env:`) that applies to all jobs.
- For these jobs, they only need to read repository contents (`actions/checkout`) and allow the Codecov action to upload coverage metadata. Codecov’s current recommended minimal scopes are typically `contents: read` and, if needed, `pull-requests: read` when used in PR contexts. The shown usage only uploads a coverage file and does not need to modify the repo.
- Therefore, we can safely set:
  - At workflow root: `permissions: contents: read`
- If in your environment Codecov needs additional scopes (like `checks: write` or `statuses: write`), they can be added later, but the minimal safe starting point is `contents: read` as CodeQL suggests.

Concretely:

- Edit `.github/workflows/ci.yml`.
- Insert a `permissions:` block after the `name: CI` line (line 1) and before `on:` (line 2), or just after `on:` if you prefer; root-level placement is supported anywhere at the top level. I’ll place it immediately after `name: CI` for clarity.
- No imports or additional methods are needed since this is just a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
