### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1


### PR DESCRIPTION
Potential fix for [https://github.com/rhel-lightspeed/linux-mcp-server/security/code-scanning/3](https://github.com/rhel-lightspeed/linux-mcp-server/security/code-scanning/3)

In general, the fix is to explicitly declare `permissions` for the workflow or individual jobs so that the `GITHUB_TOKEN` is restricted to the minimal scopes required. Since both `sanity` and `tests` jobs only check out code, install dependencies, run local commands, and upload coverage, they only need read access to repository contents; the CodeQL recommendation of `contents: read` is sufficient.

The simplest, non-functional change is to add a workflow-level `permissions` block, so it applies to all jobs that lack their own block. In `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` section and the `env:` section. This ensures both `sanity` and `tests` run with a read-only token and satisfies the CodeQL rule. No imports or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
