### PR TITLE
Add optional bcrypt dependency for asyncssh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "asyncssh>=2.14.0",
+    "asyncssh[bcrypt]>=2.14.0",
     "fastmcp",
     "pydantic-settings>=2.12.0",
     "pydantic>=2.12.4",


### PR DESCRIPTION
we removed the bcrypt dependency in a recent commit, this patch put the bcrypt back, but requiring it as an extra of asyncssh