### PR TITLE
Make substitute_command_args private

### DIFF
--- a/src/linux_mcp_server/commands.py
+++ b/src/linux_mcp_server/commands.py
@@ -38,11 +38,11 @@ class CommandSpec(BaseModel):
             host: Optional remote host address.
             **kwargs: Additional arguments passed to substitute_command_args.
         """
-        args = list(substitute_command_args(self.args, **kwargs))
+        args = list(_substitute_command_args(self.args, **kwargs))
         if self.optional_flags:
             for param_name, flag_args in self.optional_flags.items():
                 if kwargs.get(param_name):
-                    args.extend(substitute_command_args(flag_args, **kwargs))
+                    args.extend(_substitute_command_args(flag_args, **kwargs))
 
         returncode, stdout, stderr = await execute_with_fallback(tuple(args), fallback=self.fallback, host=host)
         stdout = stdout if isinstance(stdout, str) else stdout.decode("utf-8", errors="replace")
@@ -56,11 +56,11 @@ class CommandSpec(BaseModel):
             host: Optional remote host address.
             **kwargs: Additional arguments passed to substitute_command_args.
         """
-        args = list(substitute_command_args(self.args, **kwargs))
+        args = list(_substitute_command_args(self.args, **kwargs))
         if self.optional_flags:
             for param_name, flag_args in self.optional_flags.items():
                 if kwargs.get(param_name):
-                    args.extend(substitute_command_args(flag_args, **kwargs))
+                    args.extend(_substitute_command_args(flag_args, **kwargs))
 
         returncode, stdout, stderr = await execute_with_fallback(
             tuple(args), fallback=self.fallback, host=host, encoding=None
@@ -310,7 +310,7 @@ def get_command(name: str, subcommand: str = "default") -> CommandSpec:
         raise KeyError(f"Subcommand '{subcommand}' not found for '{name}'. Available: {available}") from e
 
 
-def substitute_command_args(args: Sequence[str], **kwargs: object) -> tuple[str, ...]:
+def _substitute_command_args(args: Sequence[str], **kwargs: object) -> tuple[str, ...]:
     """Substitute placeholder values in command arguments.
 
     Args:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,9 +2,9 @@
 
 import pytest
 
+from linux_mcp_server.commands import _substitute_command_args
 from linux_mcp_server.commands import get_command
 from linux_mcp_server.commands import get_command_group
-from linux_mcp_server.commands import substitute_command_args
 
 
 class TestSubstituteCommandArgs:
@@ -47,7 +47,7 @@ class TestSubstituteCommandArgs:
     )
     def test_substitution_success(self, args, kwargs, expected):
         """Test successful placeholder substitution."""
-        assert substitute_command_args(args, **kwargs) == expected
+        assert _substitute_command_args(args, **kwargs) == expected
 
     @pytest.mark.parametrize(
         ("args", "kwargs", "match"),
@@ -69,7 +69,7 @@ class TestSubstituteCommandArgs:
     def test_missing_placeholder_raises(self, args, kwargs, match):
         """Test that missing placeholders raise ValueError."""
         with pytest.raises(ValueError, match=match):
-            substitute_command_args(args, **kwargs)
+            _substitute_command_args(args, **kwargs)
 
 
 class TestGetCommandGroup:


### PR DESCRIPTION
Add some tests to ensure covrage for both `run` and `run_bytes`.