### PR TITLE
Disable FastMCP startup banner

### DIFF
--- a/src/linux_mcp_server/server.py
+++ b/src/linux_mcp_server/server.py
@@ -15,4 +15,4 @@ from linux_mcp_server.tools import *  # noqa: E402, F403
 
 
 def main():
-    mcp.run()
+    mcp.run(show_banner=False)


### PR DESCRIPTION
We do not need a huge FastMCP banner in the logs on every launch.