### PR TITLE
Fix typos in README.md and system_info.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For detailed instructions on setting up and using the Linux MCP Server, please r
 
 - **[Installation Guide]**: Detailed steps for `pip`, `uv`, and container-based deployments.
 - **[Usage Guide]**: Information on running the server, configuring LLM clients, and troubleshooting.
-- **[Cheatsheet]**: A reference for what propmts to use to invoke variaous tools.
+- **[Cheatsheet]**: A reference for what prompts to use to invoke various tools.
 
 
 [Installation Guide]: https://rhel-lightspeed.github.io/linux-mcp-server/install/

--- a/src/linux_mcp_server/tools/system_info.py
+++ b/src/linux_mcp_server/tools/system_info.py
@@ -112,7 +112,7 @@ async def get_memory_information(
 
 @mcp.tool(
     title="Get disk usage",
-    description="Get detailed disk space information including size, mount points, and utilization..",
+    description="Get detailed disk space information including size, mount points, and utilization.",
     annotations=ToolAnnotations(readOnlyHint=True),
 )
 @log_tool_call


### PR DESCRIPTION
- README.md: Fix spelling of 'prompts' and 'various'
- system_info.py: Remove double period in tool description