### PR TITLE
chore: configure Renovate for Python dependency management

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,26 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabled": false
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "labels": ["dependencies"],
+  "minimumReleaseAge": "7 days",
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "minimumReleaseAge": "0 days"
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["pep621", "pip_requirements", "pip-compile", "poetry", "pipenv"],
+      "rangeStrategy": "pin"
+    },
+    {
+      "matchDepNames": ["python"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest"],
+      "automerge": true,
+      "automergeType": "pr"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Enable Renovate with Python-focused best practices
- 7-day stabilization period for new dependency releases to avoid bleeding-edge issues
- Security vulnerability alerts bypass the cooldown and appear immediately
- Disable Python version upgrade PRs (we're pinned to specific versions long-term)
- Pin strategy for all Python package managers (pep621, pip, poetry, pipenv)
- Auto-merge GitHub Actions digest updates to reduce maintenance noise

## Configuration Details

| Setting | Value | Reason |
|---------|-------|--------|
| `minimumReleaseAge` | 7 days | Let new releases stabilize before updating |
| `vulnerabilityAlerts.minimumReleaseAge` | 0 days | Security fixes are urgent |
| `matchDepNames: ["python"]` | disabled | Python version is managed separately |
| `rangeStrategy` | pin | Reproducible builds for Python deps |
| `github-actions` | automerge | Reduce noise from digest updates |