### PR TITLE
fix(deps): bump asyncssh minimum to 2.22.0 for CVE-2023-46446

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "asyncssh[bcrypt]>=2.14.0",
+    "asyncssh[bcrypt]>=2.22.0",
     "fastmcp",
     "pydantic-settings>=2.12.0",
     "pydantic>=2.12.4",

--- a/uv.lock
+++ b/uv.lock
@@ -49,15 +49,15 @@ wheels = [
 
 [[package]]
 name = "asyncssh"
-version = "2.21.1"
+version = "2.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/b8/065c20bb5c9b8991648c0f25b13e445b4f51556cc3fdd0ad13ce4787c156/asyncssh-2.21.1.tar.gz", hash = "sha256:9943802955e2131536c2b1e71aacc68f56973a399937ed0b725086d7461c990c", size = 540515, upload-time = "2025-09-28T16:36:19.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/d5/957886c316466349d55c4de6a688a10a98295c0b4429deb8db1a17f3eb19/asyncssh-2.22.0.tar.gz", hash = "sha256:c3ce72b01be4f97b40e62844dd384227e5ff5a401a3793007c42f86a5c8eb537", size = 540523, upload-time = "2025-12-21T23:38:30.5Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/89/4a9a61bc120ca68bce92b0ea176ddc0e550e58c60ab820603bd5246e7261/asyncssh-2.21.1-py3-none-any.whl", hash = "sha256:f218f9f303c78df6627d0646835e04039a156d15e174ad63c058d62de61e1968", size = 375529, upload-time = "2025-09-28T16:36:17.68Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ae/0da2f2214fc183338af1afe5a103a2052fd03464e8eafbd827abff58a4d0/asyncssh-2.22.0-py3-none-any.whl", hash = "sha256:d16465ccdf1ed20eba1131b14415b155e047f6f5be0d19f39c2e0b61331ee0e7", size = 374938, upload-time = "2025-12-21T23:38:28.976Z" },
 ]
 
 [package.optional-dependencies]
@@ -1084,7 +1084,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asyncssh", extras = ["bcrypt"], specifier = ">=2.14.0" },
+    { name = "asyncssh", extras = ["bcrypt"], specifier = ">=2.22.0" },
     { name = "fastmcp" },
     { name = "pydantic", specifier = ">=2.12.4" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },


### PR DESCRIPTION
## Summary

- Bumps minimum asyncssh version from 2.14.0 to 2.22.0
- Fixes CVE-2023-46446 (Rogue Session Attack) - high severity (CVSS 8.1)

## Details

asyncssh versions prior to 2.14.1 are vulnerable to a rogue session attack that allows attackers to control the remote end of an SSH client session via packet injection/removal and shell emulation.

**Advisory:** https://github.com/advisories/GHSA-c35q-ffpf-5qpm

Bumping to 2.22.0 (latest) ensures all security patches since 2.14.1 are included.