### PR TITLE
docs: update VS Code configuration to use mcp.json

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -478,24 +478,22 @@ VS Code with GitHub Copilot supports MCP servers in agent mode.
 
 ### Configuration
 
-Add to your VS Code `settings.json`:
+Add to your VS Code `mcp.json`:
 
 === "pip/uv (Recommended)"
 
     ```json
-    {
-      "mcp": {
-        "servers": {
-          "linux-mcp-server": {
-            "command": "/home/YOUR_USER/.local/bin/linux-mcp-server",
-            "args": [],
-            "env": {
-              "LINUX_MCP_USER": "your-ssh-username"
-            }
-          }
-        }
+{
+  "servers": {
+    "linux-mcp-server": {
+      "command": "/home/YOUR_USER/.local/bin/linux-mcp-server",
+      "args": [],
+      "env": {
+        "LINUX_MCP_USER": "your-ssh-username" 
       }
     }
+  }
+}
     ```
 
 === "Container (Podman)"


### PR DESCRIPTION
Updates the setup instructions to use the dedicated `mcp.json` file instead of `settings.json`, aligning with the latest VS Code standards.

This change also removes the nested "mcp" property from the JSON structure, as it is no longer required in the standalone file.

Reference: https://code.visualstudio.com/docs/copilot/customization/mcp-servers