### PR TITLE
Do not strictly pin direct project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "asyncssh[bcrypt]==2.22.0",
+    "asyncssh[bcrypt]>=2.22.0",
     "fastmcp",
-    "pydantic-settings==2.12.0",
-    "pydantic==2.12.5",
+    "pydantic-settings>=2.12.0",
+    "pydantic>=2.12.5",
 ]
 dynamic = ["version"]
 license-files = ["LICENSE", "licenses/GPL-3.0.txt"]
@@ -59,17 +59,17 @@ lint = [
 ]
 
 test = [
-    "pytest-asyncio==1.3.0",
-    "pytest-cov==7.0.0",
+    "pytest-asyncio>=1.3.0",
+    "pytest-cov>=7.0.0",
     "pytest-mock",
     "pytest-randomly",
-    "pytest==9.0.2",
+    "pytest>=9.0.2",
 ]
 
 docs = [
-    "mkdocs==1.6.1",
-    "mkdocs-material==9.7.1",
-    "mkdocstrings[python]==1.0.0",
+    "mkdocs>=1.6.1",
+    "mkdocs-material>=9.7.1",
+    "mkdocstrings[python]>=1.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
   "packageRules": [
     {
       "matchManagers": ["pep621", "pip_requirements", "pip-compile", "poetry", "pipenv"],
-      "rangeStrategy": "pin"
+      "rangeStrategy": "bump"
     },
     {
       "matchDepNames": ["python"],

--- a/uv.lock
+++ b/uv.lock
@@ -1084,10 +1084,10 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asyncssh", extras = ["bcrypt"], specifier = "==2.22.0" },
+    { name = "asyncssh", extras = ["bcrypt"], specifier = ">=2.22.0" },
     { name = "fastmcp" },
-    { name = "pydantic", specifier = "==2.12.5" },
-    { name = "pydantic-settings", specifier = "==2.12.0" },
+    { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "pydantic-settings", specifier = ">=2.12.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1095,26 +1095,26 @@ dev = [
     { name = "ipdb" },
     { name = "ipython" },
     { name = "pyright" },
-    { name = "pytest", specifier = "==9.0.2" },
-    { name = "pytest-asyncio", specifier = "==1.3.0" },
-    { name = "pytest-cov", specifier = "==7.0.0" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-mock" },
     { name = "pytest-randomly" },
     { name = "ruff" },
 ]
 docs = [
-    { name = "mkdocs", specifier = "==1.6.1" },
-    { name = "mkdocs-material", specifier = "==9.7.1" },
-    { name = "mkdocstrings", extras = ["python"], specifier = "==1.0.0" },
+    { name = "mkdocs", specifier = ">=1.6.1" },
+    { name = "mkdocs-material", specifier = ">=9.7.1" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.0" },
 ]
 lint = [
     { name = "pyright" },
     { name = "ruff" },
 ]
 test = [
-    { name = "pytest", specifier = "==9.0.2" },
-    { name = "pytest-asyncio", specifier = "==1.3.0" },
-    { name = "pytest-cov", specifier = "==7.0.0" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-mock" },
     { name = "pytest-randomly" },
 ]


### PR DESCRIPTION
Adding strict version specifiers to direct project dependencies is a recipe for installation conflicts. As soon as any package is installed in the same virtual environment with overlapping dependencies, an installation error will occur.

Libraries and programs intended to be installed should use minimum version specifiers to avoid these conflicts.

The uv.lock file handles repeatable builds since that is what is used for testing and container image builds.