### PR TITLE
Update docs-serve make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,4 @@ docs:
 	uv run --locked --group docs mkdocs build
 
 docs-serve:
-	uv run --locked --group docs mkdocs serve
+	uv run --locked --group docs mkdocs serve --dev-addr localhost:8010 --livereload


### PR DESCRIPTION
Change the default port since port 8000 very often conflicts with the default port from other services that may be running locally.

Automatically reload the documentation whenever changes are made.