### PR TITLE
Consolidate path validation into shared module

### DIFF
--- a/src/linux_mcp_server/utils/validation.py
+++ b/src/linux_mcp_server/utils/validation.py
@@ -1,3 +1,61 @@
+from pathlib import Path
+
+
+class PathValidationError(ValueError):
+    """Raised when path validation fails.
+
+    This is a ValueError subclass for compatibility with existing error handling,
+    but provides a distinct type for path-specific validation failures.
+    """
+
+    pass
+
+
+def validate_path(path: str) -> str:
+    """Validate a filesystem path for security and correctness.
+
+    Performs security checks to prevent command injection and path traversal attacks:
+    - Rejects paths containing newlines, carriage returns, or null bytes
+    - Rejects paths starting with '-' (prevents flag injection)
+    - Requires absolute paths
+
+    Args:
+        path: The filesystem path to validate.
+
+    Returns:
+        The validated path in POSIX format.
+
+    Raises:
+        PathValidationError: If the path fails any validation check.
+
+    Examples:
+        >>> validate_path("/var/log/messages")
+        '/var/log/messages'
+
+        >>> validate_path("relative/path")
+        PathValidationError: Path must be absolute: relative/path
+
+        >>> validate_path("/path\\nwith\\nnewlines")
+        PathValidationError: Path contains invalid characters: /path\\nwith\\nnewlines
+    """
+    if not path:
+        raise PathValidationError("Path cannot be empty")
+
+    # Check for injection characters (newlines, carriage returns, null bytes)
+    if any(c in path for c in ["\n", "\r", "\x00"]):
+        raise PathValidationError(f"Path contains invalid characters: {path!r}")
+
+    # Prevent flag injection (paths starting with -)
+    if path.startswith("-"):
+        raise PathValidationError(f"Path cannot start with '-': {path}")
+
+    # Require absolute paths
+    if not Path(path).is_absolute():
+        raise PathValidationError(f"Path must be absolute: {path}")
+
+    return Path(path).as_posix()
+
+
 def is_empty_output(stdout: str | None) -> bool:
     """Check if command output is empty or whitespace-only.
 

--- a/tests/tools/test_storage.py
+++ b/tests/tools/test_storage.py
@@ -424,6 +424,22 @@ class TestListFilesRemote:
         assert call_kwargs["host"] == "remote.host"
 
 
+class TestPathValidation:
+    """Test path validation for storage tools."""
+
+    @pytest.mark.parametrize(
+        ("path", "expected_error"),
+        [
+            pytest.param("/path/with\nnewline", "invalid characters", id="newline_injection"),
+            pytest.param("/path/with\x00null", "invalid characters", id="null_byte_injection"),
+        ],
+    )
+    async def test_path_validation_rejects_injection_characters(self, path, expected_error, mcp_client):
+        """Test that storage tools reject paths with injection characters."""
+        with pytest.raises(ToolError, match=expected_error):
+            await mcp_client.call_tool("read_file", arguments={"path": path})
+
+
 class TestReadFile:
     async def test_read_file_success(self, tmp_path, mcp_client):
         """Test reading a file successfully."""

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -4,6 +4,8 @@ import pytest
 
 from linux_mcp_server.utils.validation import is_empty_output
 from linux_mcp_server.utils.validation import is_successful_output
+from linux_mcp_server.utils.validation import PathValidationError
+from linux_mcp_server.utils.validation import validate_path
 
 
 class TestIsEmptyOutput:
@@ -67,3 +69,68 @@ class TestIsSuccessfulOutput:
     def test_is_successful_output(self, returncode, stdout, expected):
         """Test is_successful_output with various returncode and stdout combinations."""
         assert is_successful_output(returncode, stdout) is expected
+
+
+class TestValidatePath:
+    """Test validate_path function for security and correctness."""
+
+    @pytest.mark.parametrize(
+        "path,expected",
+        [
+            ("/var/log/messages", "/var/log/messages"),
+            ("/home/user/file.txt", "/home/user/file.txt"),
+            ("/", "/"),
+            ("/tmp", "/tmp"),
+            ("/path/with spaces/file.txt", "/path/with spaces/file.txt"),
+        ],
+    )
+    def test_valid_absolute_paths(self, path, expected):
+        """Valid absolute paths are accepted and returned in POSIX format."""
+        assert validate_path(path) == expected
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "",
+            "relative/path",
+            "file.txt",
+            "./relative",
+            "../parent",
+        ],
+    )
+    def test_rejects_non_absolute_paths(self, path):
+        """Non-absolute paths raise PathValidationError."""
+        with pytest.raises(PathValidationError, match="must be absolute|cannot be empty"):
+            validate_path(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/path/with\nnewline",
+            "/path/with\rcarriage",
+            "/path/with\x00null",
+            "/path\n/injection",
+            "\n/leading/newline",
+        ],
+    )
+    def test_rejects_injection_characters(self, path):
+        """Paths with injection characters (newline, carriage return, null) are rejected."""
+        with pytest.raises(PathValidationError, match="invalid characters"):
+            validate_path(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "-rf",
+            "--help",
+            "-/path/starting/with/dash",
+        ],
+    )
+    def test_rejects_flag_injection(self, path):
+        """Paths starting with '-' are rejected to prevent flag injection."""
+        with pytest.raises(PathValidationError, match="cannot start with"):
+            validate_path(path)
+
+    def test_pathvalidationerror_is_valueerror(self):
+        """PathValidationError is a ValueError subclass for compatibility."""
+        assert issubclass(PathValidationError, ValueError)


### PR DESCRIPTION
## Summary

- Move path validation from `storage.py` to `utils/validation.py` as a reusable `validate_path()` function
- Add `PathValidationError` exception for path-specific validation failures
- Apply validation to `logs.py` before allowlist check (security improvement)

## Why

The `read_log_file` tool in `logs.py` was missing injection character validation (`\n`, `\r`, `\x00`) that existed in `storage.py`. By consolidating path validation into a shared module, we:

1. **Fix a security gap**: Log file paths are now validated for injection characters before the allowlist check
2. **Enable reuse**: Future tools can use the same validation without duplicating code
3. **Prepare for templated commands**: This lays groundwork for the templated commands feature where consistent validation will be critical

## Changes

| File | Change |
|------|--------|
| `utils/validation.py` | Add `PathValidationError` and `validate_path()` |
| `tools/storage.py` | Import from shared module, keep thin wrapper for `ToolError` |
| `tools/logs.py` | Add path validation before allowlist check |
| `tests/utils/test_validation.py` | Add 17 test cases for path validation |

## Testing

- All 107 tests for modified files pass
- Lint and type checks pass
- Note: There's a pre-existing flaky test in `test_services.py` that fails on `main` as well (unrelated to this PR)