### PR TITLE
Omit '.venv/*' from coverage report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ source = [
 ]
 omit = [
     "src/linux_mcp_server/_vendor/*/*",
-    ".venv/*"
+    ".venv/*"  # VS Code is including these files in reports for an unknown reason
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
Exclude the virtual environment from the coverage report to significantly reduce the coverage run time.