### PR TITLE
Add max-depth parameter back

### DIFF
--- a/src/linux_mcp_server/commands.py
+++ b/src/linux_mcp_server/commands.py
@@ -184,7 +184,7 @@ COMMANDS: Mapping[str, CommandGroup] = MappingProxyType(
         ),
         "list_directories_size": CommandGroup(
             commands={
-                "default": CommandSpec(args=("du", "-b", "--one-file-system", "{path}")),
+                "default": CommandSpec(args=("du", "-b", "--one-file-system", "--max-depth=1", "{path}")),
             }
         ),
         "list_directories_name": CommandGroup(


### PR DESCRIPTION
This was removed in a previous commit for testing purposes and should not have been.