### PR TITLE
fix(deps): pin pydocket <0.17 for fastmcp compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "fastmcp >=2.14.3, <3",
     "pydantic-settings >= 2.12.0",
     "pydantic >= 2.12.5",
+    "pydocket >=0.16.6, <0.17",  # Pin until fastmcp supports 0.17+ (removes _Depends)
 ]
 dynamic = ["version"]
 license-files = ["LICENSE", "licenses/GPL-3.0.txt"]

--- a/uv.lock
+++ b/uv.lock
@@ -1081,6 +1081,7 @@ dependencies = [
     { name = "fastmcp" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pydocket" },
 ]
 
 [package.optional-dependencies]
@@ -1125,6 +1126,7 @@ requires-dist = [
     { name = "gssapi", marker = "extra == 'gssapi'", specifier = ">=1.10.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
+    { name = "pydocket", specifier = ">=0.16.6,<0.17" },
 ]
 provides-extras = ["gssapi"]
 


### PR DESCRIPTION
## Summary

- Pin pydocket to `>=0.16.6, <0.17` to fix ImportError on fresh installs

## Problem

pydocket 0.17.0 refactored `docket/dependencies.py` into a `docket/dependencies/` package and stopped exporting the private `_Depends` class. fastmcp 2.14.3 imports this class directly:

```python
from docket.dependencies import Dependency, _Depends, get_dependency_parameters
```

This causes all Installation Validation CI jobs to fail with:

```
ImportError: cannot import name '_Depends' from 'docket.dependencies'
```

## Root Cause

| Environment | pydocket | Result |
|-------------|----------|--------|
| Lockfile (existing) | 0.16.6 | ✅ Works |
| Fresh install (CI) | 0.17.0 | ❌ ImportError |

## Fix

Pin pydocket to `<0.17` until fastmcp releases a version that doesn't depend on the private `_Depends` class.