### PR TITLE
refactor(tests): consolidate mock_execute_with_fallback fixture to conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,3 +79,9 @@ def mock_execute_with_fallback_for(mocker):
 def mock_getuser(mocker):
     """Mock getpass.getuser to return 'testuser'."""
     return mocker.patch("getpass.getuser", return_value="testuser")
+
+
+@pytest.fixture
+def mock_execute_with_fallback(mock_execute_with_fallback_for):
+    """Shared execute_with_fallback mock for linux_mcp_server.commands."""
+    return mock_execute_with_fallback_for("linux_mcp_server.commands")

--- a/tests/tools/storage/conftest.py
+++ b/tests/tools/storage/conftest.py
@@ -51,8 +51,3 @@ def restricted_path(tmp_path):
     yield restricted_path
 
     restricted_path.chmod(0o755)
-
-
-@pytest.fixture
-def mock_execute_with_fallback(mock_execute_with_fallback_for):
-    return mock_execute_with_fallback_for("linux_mcp_server.commands")

--- a/tests/tools/test_logs.py
+++ b/tests/tools/test_logs.py
@@ -8,12 +8,6 @@ from fastmcp.exceptions import ToolError
 
 
 @pytest.fixture
-def mock_execute_with_fallback(mock_execute_with_fallback_for):
-    """Logs-specific execute_with_fallback mock using the shared factory."""
-    return mock_execute_with_fallback_for("linux_mcp_server.commands")
-
-
-@pytest.fixture
 def mock_allowed_log_paths(mocker):
     """Fixture factory to set CONFIG.allowed_log_paths for read_log_file tests."""
 

--- a/tests/tools/test_processes.py
+++ b/tests/tools/test_processes.py
@@ -8,12 +8,6 @@ import pytest
 from fastmcp.exceptions import ToolError
 
 
-@pytest.fixture
-def mock_execute_with_fallback(mock_execute_with_fallback_for):
-    """Processes-specific execute_with_fallback mock using the shared factory."""
-    return mock_execute_with_fallback_for("linux_mcp_server.commands")
-
-
 @pytest.mark.skipif(sys.platform != "linux", reason="requires Linux ps command")
 class TestProcesses:
     async def test_list_processes(self, mcp_client):

--- a/tests/tools/test_services.py
+++ b/tests/tools/test_services.py
@@ -5,12 +5,6 @@ import sys
 import pytest
 
 
-@pytest.fixture
-def mock_execute_with_fallback(mock_execute_with_fallback_for):
-    """Services-specific execute_with_fallback mock using the shared factory."""
-    return mock_execute_with_fallback_for("linux_mcp_server.commands")
-
-
 @pytest.mark.skipif(sys.platform != "linux", reason="Only passes on Linux")
 class TestServices:
     async def test_list_services(self, mcp_client):


### PR DESCRIPTION
Consolidates duplicate `mock_execute_with_fallback` fixture definitions into `tests/conftest.py`.

- Add shared `mock_execute_with_fallback` fixture to conftest.py using existing factory
- Remove duplicate fixture definitions from 4 test files:
  - `tests/tools/test_services.py`
  - `tests/tools/test_logs.py`
  - `tests/tools/storage/conftest.py`
  - `tests/tools/test_processes.py`
- Net reduction: 18 lines of duplicate code