### PR TITLE
refactor(tests): add mock_getuser fixture to reduce test_config duplication

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,3 +73,9 @@ def mock_execute_with_fallback_for(mocker):
         )
 
     return _mock
+
+
+@pytest.fixture
+def mock_getuser(mocker):
+    """Mock getpass.getuser to return 'testuser'."""
+    return mocker.patch("getpass.getuser", return_value="testuser")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,9 +10,8 @@ from linux_mcp_server.config import Config
 class TestConfig:
     """Test cases for Config class"""
 
-    def test_custom_values(self, mocker):
+    def test_custom_values(self, mock_getuser):
         """Test that Config accepts custom values"""
-        mocker.patch("getpass.getuser", return_value="testuser")
 
         config = Config(
             user="customuser",
@@ -34,81 +33,72 @@ class TestConfig:
         assert config.key_passphrase.get_secret_value() == "secret"
         assert config.search_for_ssh_key is True
 
-    def test_env_var_override_log_level(self, mocker, monkeypatch):
+    def test_env_var_override_log_level(self, mock_getuser, monkeypatch):
         """Test that LINUX_MCP_LOG_LEVEL environment variable overrides default"""
-        mocker.patch("getpass.getuser", return_value="testuser")
         monkeypatch.setenv("LINUX_MCP_LOG_LEVEL", "WARNING")
 
         config = Config()
 
         assert config.log_level == "WARNING"
 
-    def test_env_var_override_log_dir(self, mocker, monkeypatch):
+    def test_env_var_override_log_dir(self, mock_getuser, monkeypatch):
         """Test that LINUX_MCP_LOG_DIR environment variable works"""
-        mocker.patch("getpass.getuser", return_value="testuser")
         monkeypatch.setenv("LINUX_MCP_LOG_DIR", "/custom/log/dir")
 
         config = Config()
 
         assert config.log_dir == Path("/custom/log/dir")
 
-    def test_env_var_override_log_retention_days(self, mocker, monkeypatch):
+    def test_env_var_override_log_retention_days(self, mock_getuser, monkeypatch):
         """Test that LINUX_MCP_LOG_RETENTION_DAYS environment variable works"""
-        mocker.patch("getpass.getuser", return_value="testuser")
         monkeypatch.setenv("LINUX_MCP_LOG_RETENTION_DAYS", "45")
 
         config = Config()
 
         assert config.log_retention_days == 45
 
-    def test_env_var_override_user(self, mocker, monkeypatch):
+    def test_env_var_override_user(self, mock_getuser, monkeypatch):
         """Test that LINUX_MCP_USER environment variable overrides getpass.getuser()"""
-        mocker.patch("getpass.getuser", return_value="testuser")
         monkeypatch.setenv("LINUX_MCP_USER", "envuser")
 
         config = Config()
 
         assert config.user == "envuser"
 
-    def test_env_var_override_ssh_key_path(self, mocker, monkeypatch):
+    def test_env_var_override_ssh_key_path(self, mock_getuser, monkeypatch):
         """Test that LINUX_MCP_SSH_KEY_PATH environment variable works"""
-        mocker.patch("getpass.getuser", return_value="testuser")
         monkeypatch.setenv("LINUX_MCP_SSH_KEY_PATH", "/home/user/.ssh/custom_key")
 
         config = Config()
 
         assert config.ssh_key_path == Path("/home/user/.ssh/custom_key")
 
-    def test_env_var_override_key_passphrase(self, mocker, monkeypatch):
+    def test_env_var_override_key_passphrase(self, mock_getuser, monkeypatch):
         """Test that LINUX_MCP_KEY_PASSPHRASE environment variable works"""
-        mocker.patch("getpass.getuser", return_value="testuser")
         monkeypatch.setenv("LINUX_MCP_KEY_PASSPHRASE", "my_secret_passphrase")
 
         config = Config()
 
         assert config.key_passphrase.get_secret_value() == "my_secret_passphrase"
 
-    def test_env_var_override_search_for_ssh_key(self, mocker, monkeypatch):
+    def test_env_var_override_search_for_ssh_key(self, mock_getuser, monkeypatch):
         """Test that LINUX_MCP_SEARCH_FOR_SSH_KEY environment variable works"""
-        mocker.patch("getpass.getuser", return_value="testuser")
         monkeypatch.setenv("LINUX_MCP_SEARCH_FOR_SSH_KEY", "true")
 
         config = Config()
 
         assert config.search_for_ssh_key is True
 
-    def test_env_var_override_allowed_log_paths(self, mocker, monkeypatch):
+    def test_env_var_override_allowed_log_paths(self, mock_getuser, monkeypatch):
         """Test that LINUX_MCP_ALLOWED_LOG_PATHS environment variable works"""
-        mocker.patch("getpass.getuser", return_value="testuser")
         monkeypatch.setenv("LINUX_MCP_ALLOWED_LOG_PATHS", "/var/log:/tmp:/home/logs")
 
         config = Config()
 
         assert config.allowed_log_paths == "/var/log:/tmp:/home/logs"
 
-    def test_env_ignore_empty(self, mocker, monkeypatch):
+    def test_env_ignore_empty(self, mock_getuser, monkeypatch):
         """Test that empty environment variables are ignored"""
-        mocker.patch("getpass.getuser", return_value="testuser")
         monkeypatch.setenv("LINUX_MCP_LOG_LEVEL", "")
 
         config = Config()
@@ -116,60 +106,53 @@ class TestConfig:
         # Should use default value, not empty string
         assert config.log_level == "INFO"
 
-    def test_normalize_log_level_lowercase(self, mocker):
+    def test_normalize_log_level_lowercase(self, mock_getuser):
         """Test that log_level validator converts lowercase to uppercase"""
-        mocker.patch("getpass.getuser", return_value="testuser")
 
         config = Config(log_level="debug")
 
         assert config.log_level == "DEBUG"
 
-    def test_normalize_log_level_uppercase(self, mocker):
+    def test_normalize_log_level_uppercase(self, mock_getuser):
         """Test that log_level validator keeps uppercase as is"""
-        mocker.patch("getpass.getuser", return_value="testuser")
 
         config = Config(log_level="ERROR")
 
         assert config.log_level == "ERROR"
 
-    def test_normalize_log_level_mixed_case(self, mocker):
+    def test_normalize_log_level_mixed_case(self, mock_getuser):
         """Test that log_level validator converts mixed case to uppercase"""
-        mocker.patch("getpass.getuser", return_value="testuser")
 
         config = Config(log_level="WaRnInG")
 
         assert config.log_level == "WARNING"
 
-    def test_path_conversion_log_dir(self, mocker):
+    def test_path_conversion_log_dir(self, mock_getuser):
         """Test that log_dir is properly converted to Path object"""
-        mocker.patch("getpass.getuser", return_value="testuser")
 
         config = Config(log_dir=Path("/var/log/test"))
 
         assert isinstance(config.log_dir, Path)
         assert str(config.log_dir) == "/var/log/test"
 
-    def test_path_conversion_ssh_key_path(self, mocker):
+    def test_path_conversion_ssh_key_path(self, mock_getuser):
         """Test that ssh_key_path is properly converted to Path object"""
-        mocker.patch("getpass.getuser", return_value="testuser")
 
         config = Config(ssh_key_path=Path("~/.ssh/id_rsa"))
 
         assert isinstance(config.ssh_key_path, Path)
         assert str(config.ssh_key_path) == "~/.ssh/id_rsa"
 
-    def test_log_retention_days_type(self, mocker):
+    def test_log_retention_days_type(self, mock_getuser):
         """Test that log_retention_days accepts integer"""
-        mocker.patch("getpass.getuser", return_value="testuser")
 
         config = Config(log_retention_days=15)
 
         assert isinstance(config.log_retention_days, int)
         assert config.log_retention_days == 15
 
-    def test_search_for_ssh_key_type(self, mocker):
+    def test_search_for_ssh_key_type(self, mock_getuser):
         """Test that search_for_ssh_key accepts boolean"""
-        mocker.patch("getpass.getuser", return_value="testuser")
 
         config = Config(search_for_ssh_key=True)
 
@@ -200,9 +183,8 @@ class TestEffectiveKnownHostsPath:
 class TestConfigEdgeCases:
     """Test edge cases and error conditions"""
 
-    def test_none_values_for_optional_fields(self, mocker):
+    def test_none_values_for_optional_fields(self, mock_getuser):
         """Test that optional fields can be None"""
-        mocker.patch("getpass.getuser", return_value="testuser")
 
         config = Config(
             allowed_log_paths=None,
@@ -212,17 +194,15 @@ class TestConfigEdgeCases:
         assert config.allowed_log_paths is None
         assert config.ssh_key_path is None
 
-    def test_empty_string_log_level_validation(self, mocker):
+    def test_empty_string_log_level_validation(self, mock_getuser):
         """Test log_level validator with empty string"""
-        mocker.patch("getpass.getuser", return_value="testuser")
 
         config = Config(log_level="")
 
         assert config.log_level == ""
 
-    def test_special_characters_in_paths(self, mocker):
+    def test_special_characters_in_paths(self, mock_getuser):
         """Test that paths with special characters are handled"""
-        mocker.patch("getpass.getuser", return_value="testuser")
 
         config = Config(
             log_dir=Path("/var/log/my-app/2024"),
@@ -232,9 +212,8 @@ class TestConfigEdgeCases:
         assert str(config.log_dir) == "/var/log/my-app/2024"
         assert str(config.ssh_key_path) == "/home/user/.ssh/id_rsa_2024-key"
 
-    def test_multiple_env_vars_together(self, mocker, monkeypatch):
+    def test_multiple_env_vars_together(self, mock_getuser, monkeypatch):
         """Test multiple environment variables set at once"""
-        mocker.patch("getpass.getuser", return_value="testuser")
         monkeypatch.setenv("LINUX_MCP_LOG_LEVEL", "ERROR")
         monkeypatch.setenv("LINUX_MCP_LOG_RETENTION_DAYS", "60")
         monkeypatch.setenv("LINUX_MCP_SEARCH_FOR_SSH_KEY", "1")
@@ -245,9 +224,8 @@ class TestConfigEdgeCases:
         assert config.log_retention_days == 60
         assert config.search_for_ssh_key is True
 
-    def test_model_config_settings(self, mocker):
+    def test_model_config_settings(self, mock_getuser):
         """Test that model_config is properly set"""
-        mocker.patch("getpass.getuser", return_value="testuser")
 
         config = Config()
 


### PR DESCRIPTION
- Add shared `mock_getuser` fixture to `tests/conftest.py`
- Update 22 test methods in `tests/test_config.py` to use the fixture
- Remove inline `mocker.patch("getpass.getuser", return_value="testuser")` calls
- Net reduction: 22 duplicate patch statements