### PR TITLE
[RSPEED-2404] persistence for mcp-apps

### DIFF
--- a/mcp-app/src/run-script-app.tsx
+++ b/mcp-app/src/run-script-app.tsx
@@ -6,30 +6,24 @@ import {
   useApp,
 } from "@modelcontextprotocol/ext-apps/react";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { StrictMode, useCallback, useEffect, useState } from "react";
+import { StrictMode, useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
+import {
+  ExecuteScriptResultSchema,
+  GetExecutionStateResultSchema,
+  McpAppToolParamsSchema,
+  McpAppToolResultSchema,
+  type ExecutionState,
+} from "./types";
+import { extractText, formatOutput, formatOutputForToolError } from "./utils";
 
 const IMPLEMENTATION = { name: "Run Script App", version: "1.0.0" };
-
-type GateKeeperStatus =
-  | "OK"
-  | "BAD_DESCRIPTION"
-  | "POLICY"
-  | "MODIFIES_SYSTEM"
-  | "UNCLEAR"
-  | "DANGEROUS"
-  | "MALICIOUS";
 
 const log = {
   info: console.log.bind(console, "[APP]"),
   warn: console.warn.bind(console, "[APP]"),
   error: console.error.bind(console, "[APP]"),
 };
-
-function extractText(callToolResult: CallToolResult): string {
-  const { text } = callToolResult.content?.find((c) => c.type === "text")!;
-  return text;
-}
 
 function RunScriptApp() {
   const [toolResult, setToolResult] = useState<CallToolResult | undefined>(
@@ -109,16 +103,11 @@ interface RunScriptAppInnerProps {
   toolResult: CallToolResult | undefined;
 }
 
-type ExecutionState =
-  | "initialized"
-  | "success"
-  | "failed"
-  | "rejected"
-  | "executing";
-
+// TODO: This function would be deleted in the following UI rework PR
 const pickStateColor = (state: ExecutionState): string => {
   switch (state) {
-    case "initialized":
+    case "initial":
+    case "waiting-approval":
       return "text-white";
     case "executing":
       return "text-yellow-500";
@@ -135,62 +124,133 @@ function RunScriptAppInner({
   toolResult,
 }: RunScriptAppInnerProps) {
   const [executionState, setExecutionState] =
-    useState<ExecutionState>("initialized");
+    useState<ExecutionState>("initial");
   const [executionResult, setExecutionResult] = useState<string>("");
 
-  const handleAccept = useCallback(async () => {
-    setExecutionState("executing");
+  const validatedToolRequestParams = useMemo(() => {
+    if (!toolRequestParams) {
+      return undefined;
+    }
 
-    const params = toolRequestParams || {};
-    const script = (params["script"] || "") as string;
-    const scriptType = (params["script_type"] || "bash") as string;
-    const host = params["host"] || null;
+    const parsedResult = McpAppToolParamsSchema.safeParse(toolRequestParams);
+
+    if (parsedResult.success) {
+      return parsedResult.data;
+    } else {
+      log.error(parsedResult.error);
+      return undefined;
+    }
+  }, [toolRequestParams]);
+
+  const validatedToolResult = useMemo(() => {
+    if (!toolResult) {
+      return undefined;
+    }
+
+    const parsedResult = McpAppToolResultSchema.safeParse(
+      toolResult?.structuredContent,
+    );
+
+    if (parsedResult.success) {
+      return parsedResult.data;
+    } else {
+      log.error(parsedResult.error);
+      return undefined;
+    }
+  }, [toolResult]);
+
+  useEffect(() => {
+    if (!validatedToolResult) return;
+
+    const getExecutionStateFromServer = async () => {
+      const result = await app.callServerTool({
+        name: "get_execution_state",
+        arguments: {
+          id: validatedToolResult.id,
+        },
+      });
+
+      if (result.isError) return;
+
+      const validatedResult = GetExecutionStateResultSchema.safeParse(
+        result.structuredContent,
+      );
+
+      if (validatedResult.success) {
+        setExecutionState(validatedResult.data.state);
+      }
+    };
+
+    getExecutionStateFromServer();
+  }, [app, validatedToolResult]);
+
+  const handleAccept = async () => {
+    if (!validatedToolRequestParams || !validatedToolResult) return;
+
+    setExecutionState("executing");
 
     let updatedExecutionState: ExecutionState = executionState;
     let updatedExecutionResult = executionResult;
+    let outputToModel = "";
 
     try {
       const result = await app.callServerTool({
         name: "execute_script",
-        arguments: { script: script, script_type: scriptType, host: host },
+        arguments: { id: validatedToolResult.id },
       });
 
-      if (!!result.isError) {
-        updatedExecutionState = "failed";
-      } else {
-        updatedExecutionState = "success";
+      if (result.isError) {
+        throw new Error(extractText(result));
       }
 
-      updatedExecutionResult = extractText(result);
+      const executeScriptResult = ExecuteScriptResultSchema.parse(
+        result.structuredContent,
+      );
+
+      updatedExecutionResult = executeScriptResult.output;
+      updatedExecutionState = executeScriptResult.state;
+
+      outputToModel = formatOutput(
+        validatedToolRequestParams,
+        validatedToolResult,
+        executeScriptResult,
+      );
     } catch (e) {
-      updatedExecutionState = "failed";
-      updatedExecutionResult = e as string;
-      console.error("callServerTool failed", e);
+      outputToModel = formatOutputForToolError(
+        validatedToolRequestParams,
+        validatedToolResult,
+        JSON.stringify(e),
+      );
+
+      updatedExecutionState = "failure";
+      updatedExecutionResult = JSON.stringify(e);
     }
 
     setExecutionState(updatedExecutionState);
     setExecutionResult(updatedExecutionResult);
 
-    try {
-      await app.sendMessage({
-        role: "user",
-        content: [
-          {
-            type: "text",
-            text: `The script ${script} has been executed. Here is the detail of the execution.\n--------------------------------------------\nExecution status: ${updatedExecutionState}\nExecution result: ${updatedExecutionResult}`,
-          },
-        ],
-      });
-    } catch (e) {
-      console.error(`sendMessage failed: ${e}`);
-    }
-  }, [app, toolRequestParams]);
-
-  const handleReject = () => {
-    setExecutionState("rejected");
+    app.sendMessage({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: outputToModel,
+        },
+      ],
+    });
   };
 
-  if (!toolResult || !toolRequestParams) {
+  const handleReject = async () => {
+    if (!validatedToolResult) return;
+
+    setExecutionState("rejected-user");
+    app.callServerTool({
+      name: "reject_script",
+      arguments: { id: validatedToolResult.id },
+    });
+  };
+
+  if (!validatedToolResult || !validatedToolRequestParams) {
     return (
       <div className="flex justify-center items-center min-h-[200px]">
         <div className="flex items-center">
@@ -204,7 +264,7 @@ function RunScriptAppInner({
     );
   }
 
-  switch (toolResult.structuredContent!["status"] as GateKeeperStatus) {
+  switch (validatedToolResult.status) {
     case "OK":
       return (
         <div className="p-2">
@@ -217,15 +277,15 @@ function RunScriptAppInner({
                 </span>
               </p>
               <p>
-                <strong>Script:</strong> {toolRequestParams["script"] as string}
+                <strong>Script:</strong> {validatedToolRequestParams.script}
               </p>
               <p>
                 <strong>Script Type:</strong>{" "}
-                {toolRequestParams["script_type"] as string}
+                {validatedToolRequestParams.scriptType}
               </p>
               <p>
                 <strong>Description:</strong>{" "}
-                {toolRequestParams["description"] as string}
+                {validatedToolRequestParams.description}
               </p>
               {executionResult !== null && (
                 <p>
@@ -236,14 +296,14 @@ function RunScriptAppInner({
             <div className="flex-none">
               <button
                 className="btn-primary"
-                disabled={executionState !== "initialized"}
+                disabled={executionState !== "waiting-approval"}
                 onClick={handleAccept}
               >
                 Allow
               </button>
               <button
                 className="btn-primary"
-                disabled={executionState !== "initialized"}
+                disabled={executionState !== "waiting-approval"}
                 onClick={handleReject}
               >
                 Deny
@@ -257,13 +317,10 @@ function RunScriptAppInner({
         <div className="p-2 whitespace-pre-wrap break-all">
           <p>
             <strong>Gatekeeper State:</strong>{" "}
-            <span className="text-red-500">
-              {toolResult.structuredContent!["status"] as string}
-            </span>
+            <span className="text-red-500">{validatedToolResult.status}</span>
           </p>
           <p>
-            <strong>Detail:</strong>{" "}
-            <span>{toolResult.structuredContent!["detail"] as string}</span>
+            <strong>Detail:</strong> <span>{validatedToolResult.detail}</span>
           </p>
         </div>
       );

--- a/mcp-app/src/types.ts
+++ b/mcp-app/src/types.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+
+export const McpAppToolParamsSchema = z
+  .object({
+    script: z.string(),
+    script_type: z.enum(["bash", "python"]),
+    description: z.string(),
+    host: z.string().optional().nullable(),
+  })
+  .transform((data) => ({
+    script: data.script,
+    scriptType: data.script_type,
+    description: data.description,
+    host: data.host,
+  }));
+
+export type McpAppToolParams = z.infer<typeof McpAppToolParamsSchema>;
+
+export const ExecuteScriptResultSchema = z.object({
+  state: z.enum(["success", "failure"]),
+  output: z.string(),
+});
+
+export type ExecuteScriptResult = z.infer<typeof ExecuteScriptResultSchema>;
+
+export const McpAppToolResultSchema = z.object({
+  status: z.enum([
+    "OK",
+    "BAD_DESCRIPTION",
+    "POLICY",
+    "MODIFIES_SYSTEM",
+    "UNCLEAR",
+    "DANGEROUS",
+    "MALICIOUS",
+  ]),
+  detail: z.string(),
+  id: z.string(),
+});
+
+export type McpAppToolResult = z.infer<typeof McpAppToolResultSchema>;
+
+const executionState = [
+  "initial",
+  "success",
+  "failure",
+  "rejected-user",
+  "rejected-gatekeeper",
+  "waiting-approval",
+  "executing",
+] as const;
+
+const ExecutionStateSchema = z.enum(executionState);
+
+export type ExecutionState = z.infer<typeof ExecutionStateSchema>;
+
+export const GetExecutionStateResultSchema = z.object({
+  state: ExecutionStateSchema,
+});
+
+export type GetExecutionStateResult = z.infer<
+  typeof GetExecutionStateResultSchema
+>;

--- a/mcp-app/src/utils.ts
+++ b/mcp-app/src/utils.ts
@@ -1,0 +1,52 @@
+import type {
+  McpAppToolParams,
+  ExecuteScriptResult,
+  McpAppToolResult,
+} from "./types";
+
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export const formatOutput = (
+  toolRequestParams: McpAppToolParams,
+  toolResult: McpAppToolResult,
+  executeScriptResult: ExecuteScriptResult,
+) => {
+  let result = "";
+
+  if (toolRequestParams.script.trim().split("\n").length > 1) {
+    result += `Script id=${toolResult.id} (${toolRequestParams.description}) executed`;
+  } else {
+    result += `Script \`${toolRequestParams.script}\` executed`;
+  }
+
+  if (executeScriptResult.state === "success") {
+    result += " successfully, ";
+  } else {
+    result += ", ";
+  }
+
+  result += `and returned ${executeScriptResult.state}. Output:\n${executeScriptResult.output}`;
+  return result;
+};
+
+export const formatOutputForToolError = (
+  toolRequestParams: McpAppToolParams,
+  toolResult: McpAppToolResult,
+  message: string,
+) => {
+  return toolRequestParams.script.trim().split("\n").length > 1
+    ? `Script id=${toolResult.id} (${toolRequestParams.description}) failed to execute: ${message}`
+    : `Script \`${toolRequestParams.script}\` failed to execute: ${message}`;
+};
+
+/**
+ * Extracts text content from a CallToolResult.
+ *
+ * @param callToolResult - The CallToolResult containing content to extract text from
+ * @returns The extracted text string
+ * @throws Runtime error if no text content is found in the content array
+ */
+export function extractText(callToolResult: CallToolResult): string {
+  const { text } = callToolResult.content?.find((c) => c.type === "text")!;
+  return text;
+}

--- a/src/linux_mcp_server/gatekeeper/__init__.py
+++ b/src/linux_mcp_server/gatekeeper/__init__.py
@@ -1,5 +1,6 @@
 from linux_mcp_server.gatekeeper.check_run_script import check_run_script
+from linux_mcp_server.gatekeeper.check_run_script import GatekeeperResult
 from linux_mcp_server.gatekeeper.check_run_script import GatekeeperStatus
 
 
-__all__ = ["check_run_script", "GatekeeperStatus"]
+__all__ = ["check_run_script", "GatekeeperStatus", "GatekeeperResult"]

--- a/src/linux_mcp_server/server.py
+++ b/src/linux_mcp_server/server.py
@@ -202,7 +202,10 @@ from linux_mcp_server.tools import *  # noqa: E402, F403
 # providing `mcp-app` compatibility during the initialize request.
 if CONFIG.use_mcp_apps:
     mcp.add_tool(run_script_modify_interactive)
+    mcp.add_tool(get_execution_state)
     mcp.add_tool(execute_script)
+    mcp.add_tool(reject_script)
+
 else:
     mcp.add_tool(run_script_modify)
 

--- a/src/linux_mcp_server/tools/__init__.py
+++ b/src/linux_mcp_server/tools/__init__.py
@@ -12,6 +12,8 @@ from linux_mcp_server.tools.network import get_network_interfaces
 from linux_mcp_server.tools.processes import get_process_info
 from linux_mcp_server.tools.processes import list_processes
 from linux_mcp_server.tools.run_script import execute_script
+from linux_mcp_server.tools.run_script import get_execution_state
+from linux_mcp_server.tools.run_script import reject_script
 from linux_mcp_server.tools.run_script import run_script_modify
 from linux_mcp_server.tools.run_script import run_script_modify_interactive
 from linux_mcp_server.tools.run_script import run_script_readonly
@@ -39,6 +41,7 @@ __all__ = [
     "execute_script",
     "get_cpu_information",
     "get_disk_usage",
+    "get_execution_state",
     "get_hardware_information",
     "get_journal_logs",
     "get_listening_ports",
@@ -56,6 +59,7 @@ __all__ = [
     "list_services",
     "read_file",
     "read_log_file",
+    "reject_script",
     "run_script_readonly",
     "run_script_modify",
     "run_script_modify_interactive",

--- a/src/linux_mcp_server/tools/run_script.py
+++ b/src/linux_mcp_server/tools/run_script.py
@@ -1,6 +1,10 @@
 import logging
+import secrets
 import shlex
 import typing as t
+
+from dataclasses import asdict
+from dataclasses import dataclass
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
@@ -11,6 +15,7 @@ from mcp.types import TextContent
 from mcp.types import ToolAnnotations
 
 # from pydantic import BaseModel
+from pydantic import BaseModel
 from pydantic import Field
 
 from linux_mcp_server.audit import log_tool_call
@@ -25,6 +30,9 @@ from linux_mcp_server.utils.types import Host
 
 logger = logging.getLogger("linux-mcp-server")
 
+ExecutionState = t.Literal[
+    "waiting-approval", "success", "failure", "executing", "rejected-user", "rejected-gatekeeper"
+]
 
 # This would make more sense as a StrEnum, but that generates a schema with
 # the enum in $defs, which deeply confuses (at least) the combination of
@@ -39,6 +47,90 @@ logger = logging.getLogger("linux-mcp-server")
 ScriptType = t.Literal["python", "bash"]
 SCRIPT_TYPE_PYTHON = "python"
 SCRIPT_TYPE_BASH = "bash"
+
+
+@dataclass()
+class ScriptDetails:
+    state: ExecutionState
+    script: str
+    script_type: ScriptType
+    host: Host
+
+
+# TODO: Might need a cleanup mechanism to limit the maximum number of scripts we can store
+class ScriptStore:
+    """
+    Stores script execution state across the async approval lifecycle.
+
+    When a script execution is requested, approval happens asynchronously via MCP app UI.
+    This store maps request IDs to their execution details (script, host, state) so we can
+    retrieve and execute the script after user approval, even though the original request
+    context is no longer available. It also preserve execution state (waiting-approval, executing,
+    success, failure, rejected) for the MCP app UI.
+    """
+
+    def __init__(self):
+        self._scripts: dict[str, ScriptDetails] = {}
+
+    def add_script(self, script: str, script_type: ScriptType, host: Host) -> str:
+        """
+        Add a new script to the store and generate a unique ID for it.
+
+        This method stores a script with its metadata and assigns it an initial state of
+        "waiting-approval". The generated ID can be used to retrieve or update the script later.
+
+        Args:
+            script: The script content to execute (Python or Bash code).
+            script_type: The type of script, either "python" or "bash".
+            host: The target host where the script will be executed.
+
+        Returns:
+            A unique URL-safe token (16 bytes) identifying this script execution.
+        """
+        id = secrets.token_urlsafe(16)
+        self._scripts[id] = ScriptDetails(state="waiting-approval", script=script, script_type=script_type, host=host)
+        return id
+
+    def get_script_details(self, id: str) -> ScriptDetails:
+        """
+        Retrieve the full details of a stored script by its ID.
+
+        Args:
+            id: The unique identifier for the script, as returned by add_script().
+
+        Returns:
+            A ScriptDetails object containing the script's state, content, type, and target host.
+
+        Raises:
+            KeyError: If no script exists with the given ID.
+        """
+        return self._scripts[id]
+
+    def set_script_state(self, id: str, new_state: ExecutionState):
+        """
+        Update the execution state of a stored script.
+
+        This method is used to track script lifecycle transitions, such as moving from
+        "waiting-approval" to "executing" to "success" or "failure".
+
+        Args:
+            id: The unique identifier for the script.
+            new_state: The new execution state. Valid states are:
+                - "waiting-approval": Script is pending user approval
+                - "executing": Script is currently running
+                - "success": Script completed successfully
+                - "failure": Script execution failed
+                - "rejected-user": User rejected the script
+                - "rejected-gatekeeper": Script was rejected by policy checks
+
+        Raises:
+            KeyError: If no script exists with the given ID.
+        """
+        self._scripts[id].state = new_state
+
+
+script_store = ScriptStore()
+
 
 BASH_STRICT_PREAMBLE = "set -euo pipefail; "
 
@@ -103,6 +195,12 @@ Run a script that modifies the system. The user will be asked for approval inter
 """
     + RUN_SCRIPT_COMMON_DESCRIPTION
 )
+
+
+class RunScriptInteractiveResult(BaseModel):
+    id: str
+    status: GatekeeperStatus
+    detail: str
 
 
 # class UserInfo(BaseModel):
@@ -182,25 +280,40 @@ async def run_script_readonly(
         return f"Error executing script: return code {returncode}, stderr: {stderr}"
 
 
-async def _execute_script(
-    script_type: t.Annotated[
-        ScriptType,
-        Field(description="The type of script to run (python or bash)."),
-    ],
-    script: t.Annotated[
-        str,
-        Field(description="The script to run."),
-    ],
-    host: Host = None,
-) -> str:
-    command = _wrap_script(script_type, script)
+@dataclass
+class ExecuteScriptResult:
+    state: t.Literal["success", "failure"]
+    output: str
 
-    returncode, stdout, stderr = await execute_command(command, host=host)
+
+async def _execute_script(
+    id: t.Annotated[str, Field(description="The associated ID of the script to be executed")],
+) -> ToolResult:
+    script_details = script_store.get_script_details(id)
+    command = _wrap_script(script_details.script_type, script_details.script)
+    script_store.set_script_state(id, "executing")
+    content: list[ContentBlock] = []
+
+    try:
+        returncode, stdout, stderr = await execute_command(command, host=script_details.host)
+    except Exception:
+        script_store.set_script_state(id, "failure")
+        raise
+
     if returncode == 0:
-        stdout = stdout if isinstance(stdout, str) else stdout.decode("utf-8", errors="replace")
-        return stdout
+        script_store.set_script_state(id, "success")
+
+        output = stdout if isinstance(stdout, str) else stdout.decode("utf-8", errors="replace")
+        content.append(TextContent(type="text", text=output))
+        result = ExecuteScriptResult("success", output)
     else:
-        return f"Error executing script: return code {returncode}, stderr: {stderr}"
+        script_store.set_script_state(id, "failure")
+
+        output = f"Error executing script: return code {returncode}, stderr: {stderr}"
+        content.append(TextContent(type="text", text=output))
+        result = ExecuteScriptResult("failure", output)
+
+    return ToolResult(content=content, structured_content=asdict(result))
 
 
 execute_script = Tool.from_function(
@@ -208,6 +321,21 @@ execute_script = Tool.from_function(
     name="execute_script",
     tags={"run_script", "hidden_from_model"},
     description="Execute a script; this is only available to the our mcp-app",
+    meta={"ui": {"visibility": ["app"]}},
+)
+
+
+async def _reject_script(
+    id: t.Annotated[str, Field(description="The associated ID of the script to be rejected")],
+):
+    script_store.set_script_state(id, "rejected-user")
+
+
+reject_script = Tool.from_function(
+    _reject_script,
+    name="reject_script",
+    tags={"run_script", "hidden_from_model"},
+    description="Reject a script; this is only available to the our mcp-app",
     meta={"ui": {"visibility": ["app"]}},
 )
 
@@ -243,7 +371,18 @@ async def _run_script_modify_interactive(
             )
         )
 
-    result = ToolResult(content=content, structured_content=gatekeeper_result.model_dump())
+    # Initialize execution detail to keep execution status persistent
+    # Store script and script_type so set_script_approval can retrieve them by id
+    id = script_store.add_script(script, script_type, host)
+
+    if gatekeeper_result.status != GatekeeperStatus.OK:
+        script_store.set_script_state(id, "rejected-gatekeeper")
+
+    structured_content_obj = RunScriptInteractiveResult(
+        id=id, status=gatekeeper_result.status, detail=gatekeeper_result.detail
+    )
+
+    result = ToolResult(content=content, structured_content=structured_content_obj.model_dump())
 
     return result
 
@@ -255,6 +394,7 @@ run_script_modify_interactive = Tool.from_function(
     title="Propose to run a script that modifies system",
     description=RUN_SCRIPT_MODIFY_INTERACTIVE,
     annotations=ToolAnnotations(destructiveHint=True),
+    output_schema=RunScriptInteractiveResult.model_json_schema(),
     meta={"ui": {"resourceUri": RUN_SCRIPT_APP_URI}},
 )
 
@@ -321,4 +461,19 @@ run_script_modify = Tool.from_function(
     title="Run script to modify system",
     description=RUN_SCRIPT_MODIFY_DESCRIPTION,
     annotations=ToolAnnotations(destructiveHint=True),
+)
+
+
+def _get_execution_state(id: str):
+    script_detail = script_store.get_script_details(id)
+    return {"state": script_detail.state}
+
+
+get_execution_state = Tool.from_function(
+    _get_execution_state,
+    name="get_execution_state",
+    tags={"run_script", "hidden_from_model"},
+    title="Get the execution state with request ID",
+    description="Get the execution state with request ID",
+    meta={"ui": {"visibility": ["app"]}},
 )


### PR DESCRIPTION
Adds an ExecutionPersistenceStore and hidden tools (get/set_execution_state) to the server to track script status. Updates the run-script-app frontend to sync state changes and modifies run_script_modify_interactive to include the request ID in the result.