### PR TITLE
Adjust MacOS installation notes

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -253,6 +253,17 @@ sudo pacman -S python python-pip
 
 #### Installing Python
 
+Installing Python is not needed if you are using uv (recommended) -
+it will automatically install Python versions as needed.
+
+To check your installed version of Python:
+
+```bash
+python3 --version
+```
+
+linux-mcp-server requires Python 3.10 or newer.
+
 === "Official Python Installer (Recommended)"
 
     Download from [python.org/downloads/macos](https://www.python.org/downloads/macos/) and run the installer.
@@ -272,13 +283,7 @@ sudo pacman -S python python-pip
 
 #### Installing linux-mcp-server
 
-=== "pip"
-
-    ```bash
-    pip3 install --user linux-mcp-server
-    ```
-
-=== "uv"
+=== "uv (Recommended)"
 
     Install [uv](https://docs.astral.sh/uv/#installation).
 
@@ -286,6 +291,12 @@ sudo pacman -S python python-pip
 
     ```bash
     uv tool install linux-mcp-server
+    ```
+
+=== "pip"
+
+    ```bash
+    pip3 install --user linux-mcp-server
     ```
 
 ??? failure "Command not found after installation?"

--- a/docs/install.md
+++ b/docs/install.md
@@ -313,6 +313,13 @@ linux-mcp-server requires Python 3.10 or newer.
     uv tool update-shell
     ```
 
+??? failure "No matching distribution found for linux-mcp-server"
+
+    If pip3 claims to be unable to find linux-mcp-server,
+    that probably means you have a too-old version
+    of Python. Check your python version
+    with `python3 --version` - it should be 3.10 or newer.
+
 #### SSH Setup on macOS
 
 macOS includes OpenSSH by default. To set up key-based authentication:


### PR DESCRIPTION
Recommend using uv rather than pip install, since there are less pitfalls with uv (old Python versions, conflicting library requirements) and if not using uv, say to check the version of Python, since pip will give a very unclear error if Python is too old.

This was inspired from a report from a user, who knew they already had Python installed, so skipped Python installation, tried to use pip3 --install, and got the unclear error message:

```
% pip3 install --user linux-mcp-server
ERROR: Could not find a version that satisfies the requirement linux-mcp-server (from versions: none)
ERROR: No matching distribution found for linux-mcp-server
WARNING: You are using pip version 21.2.4; however, version 26.0.1 is available.
You should consider upgrading via the '/Library/Developer/CommandLineTools/usr/bin/python3 -m pip install --upgrade pip' command.
shubansa@shubansa-mac ~ % pip3 install --user linux-mcp-server
```

(`pip3 -v install` revealed the problem as being that python3 was python-3.9)

The instructions to run `python3 --version` could be added here *without* the switch to recommending uv. I think recommending uv makes sense because:

 * It avoids the user having to worry about installing Python, which Python to use, etc.
 * It is faster and has clearer error messages
 * It installs things in a venv, which means that we get the latest version of everything, which will more closely approximate our development versions, and there are no potential conflicts with the versions required by other things installed the same way.

If preferred, I can strip this down to the `python3 --version` part.