### PR TITLE
fix(run_script): execute via wrapper instead of direct bash -c

### DIFF
--- a/src/linux_mcp_server/tools/run_script.py
+++ b/src/linux_mcp_server/tools/run_script.py
@@ -193,15 +193,7 @@ async def _execute_script(
     ],
     host: Host = None,
 ) -> str:
-    command = []
-
-    if script_type == SCRIPT_TYPE_BASH:
-        script = "# added by linux-mcp-server\nset -euo pipefail\n\n" + script
-
-    if script_type == SCRIPT_TYPE_PYTHON:
-        command = ["python3", "-c", script]
-    elif script_type == SCRIPT_TYPE_BASH:
-        command = ["bash", "-c", script]
+    command = _wrap_script(script_type, script)
 
     returncode, stdout, stderr = await execute_command(command, host=host)
     if returncode == 0:


### PR DESCRIPTION
fix mismerge since`execute_script` was merged after bash wrapper support