### PR TITLE
Do not apply target_branch tag

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -41,7 +41,6 @@ spec:
     - name: additional-tags
       value:
         - latest
-        - '{{ target_branch }}'
 
   pipelineRef:
     name: pipeline-build-multiarch


### PR DESCRIPTION
On tag push events, the `target_branch` value contains `refs/tags/[tag]`, which is an invalid value. This causes the apply-tags task to fail, causing the build to fail.

The apply-tags silently ignored this failure before but now it is failing with an error.

It is odd that the value for `target_branch` only contains `refs/*` for tag push events but for push events contains only the branch name as expected. I don't know if that is feature or bug in PaC.

See the PaC documentation on [dynamic variables](https://pipelinesascode.com/docs/guide/authoringprs/#dynamic-variables) for details.

<details>
  <summary>Example task failure log</summary>
  
```
prepare :-
2026/02/12 21:11:32 Entrypoint initialization
step-apply-additional-tags :-
time="2026-02-12T21:11:35Z" level=info msg="[param] Image URL: quay.io/redhat-user-workloads/rhel-lightspeed-tenant/linux-mcp-server:c0095474077a8dc7cdf49b3e189051d1a2c08215"
time="2026-02-12T21:11:35Z" level=info msg="[param] Image digest: sha256:75259b7a9f234d2b670446f5b8e9597aea6a2d9a26c6c9adbd22e7692f66664e"
time="2026-02-12T21:11:35Z" level=info msg="[param] Tags: latest, refs/tags/1.3.1, c009547"
time="2026-02-12T21:11:35Z" level=info msg="[param] image label: konflux.additional-tags"
time="2026-02-12T21:11:35Z" level=fatal msg="tag 'refs/tags/1.3.1' is invalid"
``` 
</details>
