### PR TITLE
run_script_modify_interactive: use default FastMCP rendering of content

### DIFF
--- a/src/linux_mcp_server/tools/run_script.py
+++ b/src/linux_mcp_server/tools/run_script.py
@@ -361,15 +361,15 @@ async def _run_script_modify_interactive(
     host: Host = None,
 ) -> ToolResult:
     gatekeeper_result = check_run_script(description, script_type, script, readonly=False)
-    content: list[ContentBlock] = []
+    content: list[ContentBlock] | None = None
 
     if gatekeeper_result.status == GatekeeperStatus.OK:
-        content.append(
+        content = [
             TextContent(
                 type="text",
                 text="The user has been asked for approval; please respond nothing to the user yet; the final result will be provided as a separate message later.",
             )
-        )
+        ]
 
     # Initialize execution detail to keep execution status persistent
     # Store script and script_type so set_script_approval can retrieve them by id


### PR DESCRIPTION
In the case where the gatekeeper rejects a script, we were returning content=[], structuredContent={...} to the model, which at least for some providers, results in the model seeing an empty result from the tool call. By instead return content=None, FastMCP will render structuredContent as the content, letting the model know what happened.