### PR TITLE
Convert --working-directory to --property=WorkingDirectory

### DIFF
--- a/src/linux_mcp_server/tools/run_script.py
+++ b/src/linux_mcp_server/tools/run_script.py
@@ -136,10 +136,9 @@ BASH_STRICT_PREAMBLE = "set -euo pipefail; "
 SYSTEMD_RUN_ARGS = [
     "--quiet",
     "--pipe",
-    "--working-directory=/tmp",
     "--collect",
     "--wait",
-    "--service-type=exec",
+    "--property=WorkingDirectory=/tmp",
     "--property=PrivateTmp=true",
     "--property=NoNewPrivileges=true",
 ]


### PR DESCRIPTION
Default service-type to 'simple', so we can remove the argument altogether.
Convert --working-directory=/tmp to a --property=WorkingDirectory=/tmp
for compatibility with older versions of systemd-run.