### PR TITLE
[RSPEED-2459] Remove diskcache from the container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -33,7 +33,8 @@ RUN python -m venv /opt/venvs/uv \
     && /opt/venvs/uv/bin/python -m pip install -U pip \
     && /opt/venvs/uv/bin/python -m pip install uv \
     && uv venv --seed "${VENVS}"/mcp \
-    && uv sync --no-cache --locked --no-dev --no-editable
+    && uv sync --no-cache --locked --no-dev --no-editable \
+    && "${VENVS}"/mcp/bin/python -m pip uninstall -y diskcache
 
 
 FROM base as final


### PR DESCRIPTION
There is a vulnerability (CVE-2025-69872, of questionable merit) with `diskcache` with no current available fix. `diskcache` is not needed directly by this project, so it can be removed.

There is no way with `pip` or `uv` to prevent it from being installed by those tools. In the container, we can manually remove it without breaking the application.

Related:
- https://github.com/grantjenks/python-diskcache/issues/357
- https://github.com/grantjenks/python-diskcache/pull/359

