### PR TITLE
fix: Only parse CLI args when running linux-mcp-server

### DIFF
--- a/src/linux_mcp_server/config.py
+++ b/src/linux_mcp_server/config.py
@@ -25,12 +25,11 @@ class Config(BaseSettings):
         env_prefix="LINUX_MCP_",
         env_ignore_empty=True,
         cli_hide_none_type=True,
-        # Only ignore errors for incorrect/extra parameters when testing
-        # https://github.com/pydantic/pydantic-settings/issues/391
-        cli_ignore_unknown_args=sys.argv[0].endswith("pytest"),
         cli_implicit_flags=True,
         cli_kebab_case=True,
-        cli_parse_args=True,
+        # Only parse CLI args when running linux-mcp-server itself, not when
+        # importing the module for other scripts (like eval scripts)
+        cli_parse_args=sys.argv[0].endswith("linux-mcp-server"),
     )
 
     # FIXME: When the next version of pydantic-settings is released, change this

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -34,15 +34,17 @@ def test_cli_version(mocker, capsys):
     ),
     ids=["streamable", "http-host"],
 )
-def test_cli_transport(mocker, args, expected):
-    mocker.patch("sys.argv", ["linux-mcp-server", *args])
+def test_cli_transport(monkeypatch: pytest.MonkeyPatch, args, expected):
+    monkeypatch.setattr("sys.argv", ["linux-mcp-server", *args])
+    monkeypatch.setitem(Config.model_config, "cli_parse_args", True)
 
     config = Config()
 
     assert config.transport_kwargs == expected
 
 
-def test_cli_transport_invalid(mocker):
-    mocker.patch("sys.argv", ["linux-mcp-server", "--transport", "nope"])
+def test_cli_transport_invalid(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("sys.argv", ["linux-mcp-server", "--transport", "nope"])
+    monkeypatch.setitem(Config.model_config, "cli_parse_args", True)
     with pytest.raises(ValidationError, match="Input should be"):
         Config()


### PR DESCRIPTION
Changed cli_parse_args to only enable CLI argument parsing when the script being run is linux-mcp-server itself. This prevents conflicts when other scripts (like eval scripts) import from linux_mcp_server and have their own CLI arguments. Settings can still be configured via environment variables in all cases.

---

I wanted to have some scripts for evaluation that imported files from linux_mcp_server; parsing the CLI args in this case is pretty annoying, so came up with this change (cherry-picked from #309). What do you think, @samdoran ?

