### PR TITLE
Convert reset_vendor fixture to save sys.modules and sys.path

### DIFF
--- a/tests/_vendor/test_vendor.py
+++ b/tests/_vendor/test_vendor.py
@@ -16,11 +16,10 @@ def reset_vendor():
     import linux_mcp_server
 
     vendor_path = str(Path(linux_mcp_server.__file__).parent / "_vendor")
-    removed_modules = [sys.modules.pop(package, None) for package in ["linux_mcp_server._vendor", "linux_mcp_server"]]
     saved_path = list(sys.path)
 
     [sys.path.remove(path) for path in sys.path if path == vendor_path]
-    [sys.modules.pop(package, None) for package in ["linux_mcp_server._vendor", "linux_mcp_server"]]
+    removed_modules = [sys.modules.pop(package, None) for package in ["linux_mcp_server._vendor", "linux_mcp_server"]]
 
     yield
 

--- a/tests/_vendor/test_vendor.py
+++ b/tests/_vendor/test_vendor.py
@@ -16,8 +16,18 @@ def reset_vendor():
     import linux_mcp_server
 
     vendor_path = str(Path(linux_mcp_server.__file__).parent / "_vendor")
+    removed_modules = [sys.modules.pop(package, None) for package in ["linux_mcp_server._vendor", "linux_mcp_server"]]
+    saved_path = list(sys.path)
+
     [sys.path.remove(path) for path in sys.path if path == vendor_path]
     [sys.modules.pop(package, None) for package in ["linux_mcp_server._vendor", "linux_mcp_server"]]
+
+    yield
+
+    sys.path[:] = saved_path
+    for module in removed_modules:
+        if module:
+            sys.modules[module.__name__] = module
 
 
 def test_package_masking():


### PR DESCRIPTION
The reset_vendor fixture in tests/_vendor/test_vendor.py removed linux_mcp_server from sys.modules so vendor tests could force a clean import. After that, any later import linux_mcp_server created a new package object. That object only gets what __init__.py defines (CONFIG, __version__, etc.); it does not automatically attach commands, connection, or __main__ as attributes.

This seems to cause problems with Python 3.10's unit tests. I'm not positive this is consistently reproducible, but I've seen it a few times locally, and every time I see errors like this:

```
E           AttributeError: module 'linux_mcp_server' has no attribute 'connection'
```

The fix has been to apply this patch to the `reset_vendor` fixture. I have integrated these same changes to the `experimental/guarded-command-execution branch` and the `convert-services-structured-output` to fix failing Python 3.10 unit tests.