### PR TITLE
test: add 100% test coverage for check_run_script.py

### DIFF
--- a/src/linux_mcp_server/gatekeeper/check_run_script.py
+++ b/src/linux_mcp_server/gatekeeper/check_run_script.py
@@ -137,6 +137,8 @@ class GatekeeperResult(BaseModel):
                 # We don't provide detail here to make it harder for a malicious model
                 # to figure out workarounds
                 return "Possibly malicious script: not allowed"
+            case _:  # pragma: no cover
+                raise ValueError(f"Unknown status: {self.status}")
 
     @classmethod
     def parse_from_description(cls, description: str) -> "GatekeeperResult":

--- a/tests/gatekeeper/test_check_run_script.py
+++ b/tests/gatekeeper/test_check_run_script.py
@@ -1,7 +1,21 @@
+import importlib
+
+from unittest.mock import Mock
+
 import pytest
+
+from litellm import Choices
+from litellm import ModelResponse
 
 from linux_mcp_server.gatekeeper import GatekeeperResult
 from linux_mcp_server.gatekeeper import GatekeeperStatus
+from linux_mcp_server.gatekeeper.check_run_script import check_run_script
+from linux_mcp_server.gatekeeper.check_run_script import get_model
+
+
+# Workaround: with python-3.10, mocker.patch("linux_mcp_server.gatekeeper.check_run_script.X")
+# doesn't work because it finds the imported check_run_script function rather than the module.
+check_run_script_module = importlib.import_module("linux_mcp_server.gatekeeper.check_run_script")
 
 
 RESULT_CASES = [
@@ -37,3 +51,91 @@ class TestGatekeeperResultDescription:
             assert parsed.detail == "not allowed"
         else:
             assert parsed.detail == detail
+
+    def test_parse_from_description_unknown_prefix(self):
+        with pytest.raises(ValueError, match="Unknown description prefix"):
+            GatekeeperResult.parse_from_description("Unknown prefix: something")
+
+
+class TestGetModel:
+    def test_returns_configured_model(self, mocker):
+        mocker.patch.object(
+            check_run_script_module,
+            "CONFIG",
+            gatekeeper_model="test-model",
+        )
+        assert get_model() == "test-model"
+
+    def test_raises_when_model_not_configured(self, mocker):
+        mocker.patch.object(
+            check_run_script_module,
+            "CONFIG",
+            gatekeeper_model=None,
+        )
+        with pytest.raises(ValueError, match="must set gatekeeper_model"):
+            get_model()
+
+
+class TestCheckRunScript:
+    @pytest.fixture
+    def mock_litellm(self, mocker):
+        mocker.patch.object(
+            check_run_script_module,
+            "CONFIG",
+            gatekeeper_model="test-model",
+        )
+        mock_completion = mocker.patch.object(check_run_script_module, "completion")
+        mock_get_params = mocker.patch.object(check_run_script_module, "get_supported_openai_params")
+        return mock_completion, mock_get_params
+
+    def _make_response(self, content: str) -> ModelResponse:
+        message = Mock()
+        message.content = content
+        choice = Mock(spec=Choices)
+        choice.message = message
+        response = Mock(spec=ModelResponse)
+        response.choices = [choice]
+        return response
+
+    def test_rejects_script_with_end_of_script(self):
+        result = check_run_script(description="test", script_type="bash", script="echo END_OF_SCRIPT", readonly=True)
+        assert result.status == GatekeeperStatus.MALICIOUS
+        assert "end_of_script" in result.detail
+
+    @pytest.mark.parametrize(
+        "supported_params,expect_response_format",
+        [
+            (["response_format", "temperature"], True),
+            (["temperature"], False),
+            (None, False),
+        ],
+    )
+    def test_response_format_handling(self, mock_litellm, supported_params, expect_response_format):
+        mock_completion, mock_get_params = mock_litellm
+        mock_get_params.return_value = supported_params
+        mock_completion.return_value = self._make_response('{"status": "OK", "detail": ""}')
+
+        result = check_run_script(description="test", script_type="bash", script="echo hi", readonly=True)
+        assert result.status == GatekeeperStatus.OK
+
+        call_kwargs = mock_completion.call_args.kwargs
+        if expect_response_format:
+            assert call_kwargs["response_format"] is GatekeeperResult
+        else:
+            assert call_kwargs["response_format"] is None
+
+    @pytest.mark.parametrize(
+        "response_text,error_match",
+        [
+            ("not valid json", "Failed to parse response"),
+            ('"just a string"', "Invalid response format"),
+            ('{"status": "INVALID_STATUS"}', "Bad status"),
+        ],
+    )
+    def test_parse_errors(self, mock_litellm, response_text, error_match):
+        mock_completion, mock_get_params = mock_litellm
+        mock_get_params.return_value = None  # No response_format support
+        mock_completion.return_value = self._make_response(response_text)
+
+        with pytest.raises(RuntimeError, match=error_match):
+            check_run_script(description="test", script_type="bash", script="echo hi", readonly=True)


### PR DESCRIPTION
Add tests for get_model(), check_run_script(), and parse_from_description() error handling. Mock litellm completion calls and verify response_format is passed correctly based on model capabilities.