### PR TITLE
Add comprehensive documentation for Guarded Command execution

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -631,7 +631,7 @@ See [Guarded Command Execution](guarded-command-execution.md)
 | `LINUX_MCP_VERIFY_HOST_KEYS` | `False` | Verify remote host identity via known_hosts |
 | `LINUX_MCP_KNOWN_HOSTS_PATH` | (none) | Custom path to known_hosts file |
 
-### Guarded Command Exection settings (run_script toolset)
+### Guarded Command Execution settings (run_script toolset)
 
 These are used when `LINUX_MCP_TOOLSET` is set to `run_script` or `both`
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -606,6 +606,14 @@ Configure these environment variables in the `env` section of your client config
 !!! note "When to use HTTP transports"
     Some clients, like Claude Desktop, require `stdio`.
 
+### Enabled tools
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LINUX_MCP_TOOLSET` | `fixed` | Toolset: `fixed`, `run_script`, or `both` |
+
+See [Guarded Command Execution](guarded-command-execution.md)
+
 ### SSH Connection Settings
 
 | Variable | Description | Example |
@@ -623,6 +631,17 @@ Configure these environment variables in the `env` section of your client config
 | `LINUX_MCP_VERIFY_HOST_KEYS` | `False` | Verify remote host identity via known_hosts |
 | `LINUX_MCP_KNOWN_HOSTS_PATH` | (none) | Custom path to known_hosts file |
 
+### Guarded Command Exection settings (run_script toolset)
+
+These are used when `LINUX_MCP_TOOLSET` is set to `run_script` or `both`
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LINUX_MCP_GATEKEEPER_MODEL` | (none) | Required: [LiteLLM model name](https://docs.litellm.ai/docs/providers) to use |
+| `LINUX_MCP_ALWAYS_CONFIRM_SCRIPTS` | `False` | All scripts must be confirmed by the user |
+| Other environment variables | (none) | As required by the LiteLLM provider, .e.g. OPENAI_API_KEY |
+
+See [Guarded Command Execution](guarded-command-execution.md)
 ### Feature-Specific Settings
 
 | Variable | Required For | Description | Example |

--- a/docs/guarded-command-execution.md
+++ b/docs/guarded-command-execution.md
@@ -9,7 +9,7 @@ instead of simply calling fixed, read-only tools.
 This greatly increases the functionality of linux-mcp-server.
 It allows models to use all their knowledge of Linux operating systems to diagnose and even fix problems on the target system.
 
-However, along with the increased power,
+However, along with the increased functionality,
 comes a greater risk of "prompt injection" attacks.
 In a prompt injection attack, an attacker disguises commands in data that the model reads, and tricks the model into doing something that the user doesn't intend.
 To control these risks, when Guarded Command Execution is enabled,
@@ -26,6 +26,7 @@ there are multiple levels of guardrails enabled:
 3. if checks pass, the model calls `run_script` or `run_script_with_confirmation` to actually execute the script on the target machine.
 4. If `run_script_with_confirmation` is required, the user is asked to approve the call.
 5. The script is executed on the target machine, in an operating-system level sandbox if possible.
+
 ## The Gatekeeper Model
 
 The gatekeeper model is simply a *user-provided* chat model.
@@ -127,7 +128,7 @@ The following three tools should be configured to be allowed without user confir
 
 The following tool should be configured to ask the user each time:
 
-`run_script_with_confirmation` (used when mcp-apps are unavailable)
+* `run_script_with_confirmation` (used when mcp-apps are unavailable)
 
 !!! warning
     Setting `run_script_with_confirmation` to Always Allow is dangerous and not recommended.

--- a/docs/guarded-command-execution.md
+++ b/docs/guarded-command-execution.md
@@ -1,0 +1,150 @@
+# Guarded Command Execution
+
+Guarded Command Execution is an **experimental** feature of linux-mcp-server.
+When it is enabled (by setting `LINUX_MCP_TOOLSET` to `run_script` or `both`),
+linux-mcp-server exposes additional tools that allow models
+to provide a script to run on the target system,
+instead of simply calling fixed read-only tools.
+
+This greatly increases the power of linux-mcp-server.
+It allows models to use all their knowledge of Linux operating systems to diagnose and even fix problems on the target system.
+
+However, along with the increased power,
+comes an increased risk of "prompt injection" attacks.
+In a prompt injection attack, an attacker disguises commands in data that the model reads, and tricks the model into doing something that the user doesn't intend.
+To control these risks, when Guarded Command Execution is enabled,
+there are multiple levels of guardrails enabled:
+
+ * **Gatekeeper model**: A separate model called the Gatekeeper does an initial check of the command to make sure that it looks OK and matches the provided description.
+ * **Human in the loop**: commands that modify the system are flagged for human approval. The human can review the description and optionally the exact command.
+ * **Sandboxing**: When possible, the command is run in an os-level sandbox with limited permissions. (NOTE: sandboxing is currently rudimentary.)
+
+## Step-by-step
+
+Step 1. The model calls the `validate_script` tool to check the script,
+passing in a human-readable description<br>
+Step 2. linux-mcp-server uses the gatekeeper model to check
+that the script is safe.<br>
+Step 3. if checks pass,
+the model calls `run_script` or `run_script_with_confirmation`
+to actually execute the script on the target machine.<br>
+Step 4. If `run_script_with_confirmation` is required,
+the user is asked to approve the call.
+Step 5. the script is executed on the target machine,
+possibly in an operating-system level sandbox.
+
+## The Gatekeeper Model
+
+The gatekeeper model is simply a *user-provided* chat model.
+It is given the script and a special prompt asking it to check the script. The model checks if the script:
+
+* Matches the description
+* Is read-only if that was specified by the model.
+* Conforms to policy.
+* Is clear and simple and written in an obvious, expected manner.
+* Does not contain malicious code or introduce security vulnerabilities on the system.
+
+Policy is currently hardcoded:
+
+ * Software can only be installed from pre-configured repositories.
+   No new repositories may be added.
+ * Except for installing software from pre-configured repositories,
+   nothing may be downloaded from the internet.
+
+In the future,
+administrators will be able to customize the policy to their particular needs.
+
+The security of Guarded Command Execution depends
+on configuring an appropriate gatekeeper model.
+
+Some models that we have tested include:
+
+| Model | Model Type | Score |
+|------------|-------|--------|
+| Claude Opus 4.6 | Frontier model | ?? |
+| gpt-oss:120b | Datacenter | ?? |
+| gpt-oss:20b  | Workstation |?? |
+
+The scores come from the evaluation suite provided with the linux-mcp-server source code. If you use a different model,
+running the evaluation suite is recommended.
+
+The scores give an approximate sense of the capability of the model acting as a gatekeeper -
+actual performance in real-world situations may vary.
+Smaller models than those listed above are *not recommended*.
+
+## Human In The Loop
+
+To provide a better experience for the human approving the call:
+
+ * The model provides a human readable description, and the gatekeeper model checks that it matches the script.
+ * The user is only prompted to approve more dangerous commands (typically calls that modify the target system), but other commands can run non-interactively.
+ * When possible a custom approval UI is embedded into the chat client using an [mcp-app](https://modelcontextprotocol.io/extensions/apps/).
+
+When mcp-apps are available,
+the server exposes `run_script_interactive`,
+which uses a custom approval UI embedded in the chat client.
+When mcp-apps are not available,
+the server exposes `run_script_with_confirmation` instead,
+which relies on the chat client's built-in confirmation mechanism.
+
+## Configuring Guarded Command Execution
+
+**Enable Guarded Command Execution**
+
+Set `LINUX_MCP_TOOLSET` to `both` or `run_script`.
+
+Three values are supported for `LINUX_MCP_TOOLSET`:
+
+* **fixed**: only read-only tools with fixed functionality
+* **run_script**: only the Guarded Command Execution tools.
+* **both**: all the tools
+
+ Running in `both` mode may not produce better results than `run_script` alone —
+ everything can be done with the `run_script` tools,
+ and the greater number of tools may confuse the AI agent.
+ Try it both ways.
+
+Example:
+
+```sh
+LINUX_MCP_TOOLSET=run_script
+```
+
+**Configure a Gatekeeper Model**
+
+Set `LINUX_MCP_GATEKEEPER_MODEL` to the name of the model you want to use. Additional environment
+variables will be needed to configure credentials. See the
+[LiteLLM documentation](https://docs.litellm.ai/docs/providers).
+
+Example:
+
+```sh
+LINUX_MCP_GATEKEEPER_MODEL=openai/chatgpt-5.2
+OPENAI_API_KEY=<....>
+```
+
+
+**Configure your client's tool policy**
+
+The following three tools should be configured to be allowed without user confirmation:
+
+`validate_script`<br>
+`run_script`<br>
+`run_script_interactive` (used when mcp-apps are available)
+
+The following tool should be configured to ask the user each time:
+
+`run_script_with_confirmation` (used when mcp-apps are unavailable)
+
+!!! warning
+    Setting `run_script_with_confirmation` to Always Allow is dangerous and not recommended.
+
+Details of how to do this are client specific — it might be done through a config file,
+or interactively when each tool is first called.
+
+
+**Optional: configure a strict approval policy**
+
+`LINUX_MCP_ALWAYS_CONFIRM_SCRIPTS=True` can be set to force *all* scripts to be run via `run_script_with_confirmation`, including read-only scripts.
+This is not recommended — **it's better to let the user focus on higher risk approvals** and avoid "approval fatigue."
+

--- a/docs/guarded-command-execution.md
+++ b/docs/guarded-command-execution.md
@@ -4,35 +4,28 @@ Guarded Command Execution is an **experimental** feature of linux-mcp-server.
 When it is enabled (by setting `LINUX_MCP_TOOLSET` to `run_script` or `both`),
 linux-mcp-server exposes additional tools that allow models
 to provide a script to run on the target system,
-instead of simply calling fixed read-only tools.
+instead of simply calling fixed, read-only tools.
 
-This greatly increases the power of linux-mcp-server.
+This greatly increases the functionality of linux-mcp-server.
 It allows models to use all their knowledge of Linux operating systems to diagnose and even fix problems on the target system.
 
 However, along with the increased power,
-comes an increased risk of "prompt injection" attacks.
+comes a greater risk of "prompt injection" attacks.
 In a prompt injection attack, an attacker disguises commands in data that the model reads, and tricks the model into doing something that the user doesn't intend.
 To control these risks, when Guarded Command Execution is enabled,
 there are multiple levels of guardrails enabled:
 
  * **Gatekeeper model**: A separate model called the Gatekeeper does an initial check of the command to make sure that it looks OK and matches the provided description.
  * **Human in the loop**: commands that modify the system are flagged for human approval. The human can review the description and optionally the exact command.
- * **Sandboxing**: When possible, the command is run in an os-level sandbox with limited permissions. (NOTE: sandboxing is currently rudimentary.)
+ * **Sandboxing**: When possible, the command is run in an OS-level sandbox with limited permissions. (NOTE: sandboxing is currently rudimentary.)
 
 ## Step-by-step
 
-Step 1. The model calls the `validate_script` tool to check the script,
-passing in a human-readable description<br>
-Step 2. linux-mcp-server uses the gatekeeper model to check
-that the script is safe.<br>
-Step 3. if checks pass,
-the model calls `run_script` or `run_script_with_confirmation`
-to actually execute the script on the target machine.<br>
-Step 4. If `run_script_with_confirmation` is required,
-the user is asked to approve the call.
-Step 5. the script is executed on the target machine,
-possibly in an operating-system level sandbox.
-
+1. The model calls the `validate_script` tool to check the script, passing in a human-readable description
+2. linux-mcp-server uses the gatekeeper model to check that the script is safe.
+3. if checks pass, the model calls `run_script` or `run_script_with_confirmation` to actually execute the script on the target machine.
+4. If `run_script_with_confirmation` is required, the user is asked to approve the call.
+5. The script is executed on the target machine, in an operating-system level sandbox if possible.
 ## The Gatekeeper Model
 
 The gatekeeper model is simply a *user-provided* chat model.
@@ -99,7 +92,7 @@ Three values are supported for `LINUX_MCP_TOOLSET`:
 * **run_script**: only the Guarded Command Execution tools.
 * **both**: all the tools
 
- Running in `both` mode may not produce better results than `run_script` alone —
+**Note**: Running in `both` mode may not produce better results than `run_script` alone —
  everything can be done with the `run_script` tools,
  and the greater number of tools may confuse the AI agent.
  Try it both ways.
@@ -113,8 +106,8 @@ LINUX_MCP_TOOLSET=run_script
 **Configure a Gatekeeper Model**
 
 Set `LINUX_MCP_GATEKEEPER_MODEL` to the name of the model you want to use. Additional environment
-variables will be needed to configure credentials. See the
-[LiteLLM documentation](https://docs.litellm.ai/docs/providers).
+variables may be needed to configure credentials. See the
+[LiteLLM documentation](https://docs.litellm.ai/docs/providers) for details on how to configure your provider.
 
 Example:
 
@@ -128,9 +121,9 @@ OPENAI_API_KEY=<....>
 
 The following three tools should be configured to be allowed without user confirmation:
 
-`validate_script`<br>
-`run_script`<br>
-`run_script_interactive` (used when mcp-apps are available)
+* `validate_script`
+* `run_script`
+* `run_script_interactive` (used when mcp-apps are available)
 
 The following tool should be configured to ask the user each time:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -65,59 +65,6 @@ linux-mcp-server --user admin --ssh-key-path ~/.ssh/id_rsa --verify-host-keys
 linux-mcp-server --allowed-log-paths "/var/log/messages,/var/log/secure,/var/log/audit/audit.log"
 ```
 
-### Enabling running arbitrary commands ***EXPERIMENTAL***
-
-The default tools exposed by the linux-mcp-server allow the AI agent a wide range of tools
-to query information about specific aspects of the target machine, as described below.
-However, the agent is not able to run arbitrary commands. It is also possible (as an experimental
-feature), to enable additional tools to allow the AI agent to run arbitrary commands,
-in read-only or read-write mode.
-
-```
-export LINUX_MCP_TOOLSET="run_script"
-export LINUX_MCP_GATEKEEPER_MODEL="gpt-5.2"
-export OPENAI_API_KEY="Your API key"
-```
-
-Three values are supported for LINUX_MCP_TOOLSET:
-
-* **FIXED**: only read-only tools with fixed functionality
-* **RUN_SCRIPT**: only `run_script_readonly` and `run_script_modify`
-* **BOTH**: all the tools
-
-Running in `both` mode will not necessarily produce better results then only using
-the `run_script` toolset - the greater number of tools may confuse the AI agent.
-Try it both ways.
-
-To try to avoid actions that are dangerous or that do unintended things, the scripts
-passed to the `run_script_*` tools are checked using a gatekeeper model that reviews
-the commands before running them. You must configure this model. Configuration is
-done by using the `LINUX_MCP_GATEKEEPER_MODEL` environment variable. Additional environment
-variables will be needed to configure credentials. See the
-[LiteLLM documentation](https://docs.litellm.ai/docs/providers).
-
-#### Try the mcp-app feature with compatible GUI application (i.e., Goose Desktop, Claude Desktop...etc)
-
-1. Generate the bundled app
-
-```shell
-cd mcp-app
-npm install
-npm run build:prod
-```
-
-2. Set up environment variables
-
-Please set this environment variable before launching the GUI, or add it to the environment configuration used by the application to spawn the linux-mcp-server.
-
-```
-export LINUX_MCP_USE_MCP_APPS=true
-```
-
-Note: Ensure LINUX_MCP_TOOLSET and LINUX_MCP_GATEKEEPER_MODEL are set in your environment, along with the specific API key or configuration variable required for your chosen gatekeeper model. 
-
-Once configured, `run_script_modify_interactive` will replace `run_script_modify`. This tool launches an integrated MCP app, allowing you to review, approve, or reject script modifications directly through the UI.
-
 
 ### Using with AI Agents
 
@@ -293,22 +240,72 @@ Lists immediate subdirectories under a specified path with flexible sorting opti
 - "Show me recently modified directories in /home" → `list_directories(path="/home", order_by="modified", sort="descending")`
 - "What directories in /tmp were changed (oldest first)?" → `list_directories(path="/tmp", order_by="modified", sort="ascending")`
 
-#### `run_script_readonly` (experimental)
-Runs a script on a system in read-only mode.
+#### `run_script` (experimental)
+Runs a script on a system. `validate_script` must be called first to check if the script matches
+the description and appears safe, and the parameters should exactly match those provided there.
+
+This is used when `validate_script` returns `needs_confirmation: false` in the result,
+and it will error out if `validate_script` indicated that confirmation was needed.
+
+This tool *does not* need manual user approval, because the tool call is considered to be
+safe. For most secure operation, `LINUX_MCP_ALWAYS_CONFIRM_SCRIPTS` an be set so that scripts must be
+manually confirmed.
 
 **Parameters**
 - `description`: Description of what the script does - e.g. 'Collect SELinux messages from the system logs.'
 - `script_type`: The type of script to run (`python` or `bash`)
 - `script`: The script to run
+- `readonly`: Should be true if the script does not modify the system."
+- `token`: token returned from `validate_script`
 
-#### `run_script_modify` (experimental)
-Runs a script on a system to modify files or settings.
+
+#### `run_script_with_confirmation` (experimental)
+Runs a script on a system. `validate_script` must be called first to check if the script matches
+the description and appears safe, and the parameters should exactly match those provided there.
+
+This is used when `validate_script` returns `needs_confirmation: true` in the result.
+This tool *needs to be manually approved by the user*.
 
 **Parameters**
 - `description`: Description of what the script does - e.g. 'Modify file permissions on nginx.conf to fix startup errors.'
 - `script_type`: The type of script to run (`python` or `bash`)
 - `script`: The script to run
+- `readonly`: Should be true if the script does not modify the system."
+- `token`: token returned from `validate_script`
 
+
+#### `run_script_interactive` (experimental)
+Runs a script on a system after using an embedded
+[mcp-app](https://modelcontextprotocol.io/extensions/apps/) to ask the user for confirmation.
+`validate_script` must be called first to check if the script matches
+the description and appears safe, and the parameters should exactly match those provided there.
+
+This is used when `validate_script` returns `needs_confirmation: true` in the result.
+This tool *does not* need manual user approval, because that will be done by the embedded
+user interface.
+
+**Parameters**
+- `description`: Description of what the script does - e.g. 'Modify file permissions on nginx.conf to fix startup errors.'
+- `script_type`: The type of script to run (`python` or `bash`)
+- `script`: The script to run
+- `readonly`: Should be true if the script does not modify the system."
+- `token`: token returned from `validate_script`
+
+
+#### `validate_script` (experimental)
+Called to check a script before running it. This is a safe tool that never modifies the target system.
+
+**Parameters**
+- `description`: Description of what the script does - e.g. 'Modify file permissions on nginx.conf to fix startup errors.'
+- `script_type`: The type of script to run (`python` or `bash`)
+- `script`: The script to run
+- `readonly`: Should be true if the script does not modify the system."
+
+Returns an object with the following members:
+
+**Returns**
+- `needs_confirmation`: If `true`, call `run_script_with_confirmation` to run the script, otherwise `run_script`.
+- `token`: token to pass to `run_script` or `run_script_with_confirmation`
 
 ## Configuration
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -248,14 +248,14 @@ This is used when `validate_script` returns `needs_confirmation: false` in the r
 and it will error out if `validate_script` indicated that confirmation was needed.
 
 This tool *does not* need manual user approval, because the tool call is considered to be
-safe. For most secure operation, `LINUX_MCP_ALWAYS_CONFIRM_SCRIPTS` an be set so that scripts must be
+safe. For more secure operation, `LINUX_MCP_ALWAYS_CONFIRM_SCRIPTS` can be set so that scripts must be
 manually confirmed.
 
 **Parameters**
 - `description`: Description of what the script does - e.g. 'Collect SELinux messages from the system logs.'
 - `script_type`: The type of script to run (`python` or `bash`)
 - `script`: The script to run
-- `readonly`: Should be true if the script does not modify the system."
+- `readonly`: Should be true if the script does not modify the system.
 - `token`: token returned from `validate_script`
 
 
@@ -270,7 +270,7 @@ This tool *needs to be manually approved by the user*.
 - `description`: Description of what the script does - e.g. 'Modify file permissions on nginx.conf to fix startup errors.'
 - `script_type`: The type of script to run (`python` or `bash`)
 - `script`: The script to run
-- `readonly`: Should be true if the script does not modify the system."
+- `readonly`: Should be true if the script does not modify the system.
 - `token`: token returned from `validate_script`
 
 
@@ -288,7 +288,7 @@ user interface.
 - `description`: Description of what the script does - e.g. 'Modify file permissions on nginx.conf to fix startup errors.'
 - `script_type`: The type of script to run (`python` or `bash`)
 - `script`: The script to run
-- `readonly`: Should be true if the script does not modify the system."
+- `readonly`: Should be true if the script does not modify the system.
 - `token`: token returned from `validate_script`
 
 
@@ -299,7 +299,7 @@ Called to check a script before running it. This is a safe tool that never modif
 - `description`: Description of what the script does - e.g. 'Modify file permissions on nginx.conf to fix startup errors.'
 - `script_type`: The type of script to run (`python` or `bash`)
 - `script`: The script to run
-- `readonly`: Should be true if the script does not modify the system."
+- `readonly`: Should be true if the script does not modify the system.
 
 Returns an object with the following members:
 

--- a/src/linux_mcp_server/gatekeeper/check_run_script.py
+++ b/src/linux_mcp_server/gatekeeper/check_run_script.py
@@ -68,7 +68,7 @@ Your job is to check that:
 * It conforms to the general policies outlined above.
 * The script is clear and simple and written in an obvious, expected
   manner.
-* The script does not contain malicious code or introduce security vulnerabities
+* The script does not contain malicious code or introduce security vulnerabilities
   on the system.
 
 It is *OK* if the script does not consider every possible failure mode, as long


### PR DESCRIPTION
Add a new file with comprehensive docs on Guarded Command Execution using the new architecture from #321.

The configuration and tool docs are updated to include the latest information well.