### PR TITLE
feat(run_script): simplify tool parameters and merge toolsets

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -242,7 +242,7 @@ Lists immediate subdirectories under a specified path with flexible sorting opti
 
 #### `run_script` (experimental)
 Runs a script on a system. `validate_script` must be called first to check if the script matches
-the description and appears safe, and the parameters should exactly match those provided there.
+the description and appears safe.
 
 This is used when `validate_script` returns `needs_confirmation: false` in the result,
 and it will error out if `validate_script` indicated that confirmation was needed.
@@ -252,19 +252,16 @@ safe. For more secure operation, `LINUX_MCP_ALWAYS_CONFIRM_SCRIPTS` can be set s
 manually confirmed.
 
 **Parameters**
-- `description`: Description of what the script does - e.g. 'Collect SELinux messages from the system logs.'
-- `script_type`: The type of script to run (`python` or `bash`)
-- `script`: The script to run
-- `readonly`: Should be true if the script does not modify the system.
 - `token`: token returned from `validate_script`
 
 
 #### `run_script_with_confirmation` (experimental)
 Runs a script on a system. `validate_script` must be called first to check if the script matches
-the description and appears safe, and the parameters should exactly match those provided there.
+the description and appears safe. The parameters should exactly match those provided to `validate_script`.
 
 This is used when `validate_script` returns `needs_confirmation: true` in the result.
-This tool *needs to be manually approved by the user*.
+This tool *needs to be manually approved by the user*. The parameters are repeated so they
+are visible in the client's approval UI.
 
 **Parameters**
 - `description`: Description of what the script does - e.g. 'Modify file permissions on nginx.conf to fix startup errors.'

--- a/mcp-app/src/types.ts
+++ b/mcp-app/src/types.ts
@@ -11,12 +11,16 @@ export const McpAppToolParamsSchema = z
     script: z.string(),
     script_type: scriptTypeSchema,
     description: z.string(),
+    readonly: z.boolean(),
+    token: z.string(),
     host: z.string().optional().nullable(),
   })
   .transform((data) => ({
     script: data.script,
     scriptType: data.script_type,
     description: data.description,
+    readonly: data.readonly,
+    token: data.token,
     host: data.host,
   }));
 

--- a/src/linux_mcp_server/config.py
+++ b/src/linux_mcp_server/config.py
@@ -23,7 +23,6 @@ class Toolset(StrEnum):
 
     FIXED = "fixed"
     RUN_SCRIPT = "run_script"
-    VALIDATE_SCRIPT = "validate_script"
     BOTH = "both"
 
 

--- a/src/linux_mcp_server/server.py
+++ b/src/linux_mcp_server/server.py
@@ -56,33 +56,7 @@ These tools map to six areas:
 - **File paths:** must be absolute
 """
 
-INSTRUCTIONS_RUN_SCRIPT = """You have access to tools that execute Python or Bash scripts you supply on the target system, for inspection or for making changes.
-
-## Script tools
-
-- **run_script_readonly:** Run a Python or Bash script that only inspects the system. Use for queries and data collection.
-- **run_script_modify:** Run a Python or Bash script that may change files or configuration. Use only when changes are required.
-
-## Usage
-
-- Prefer readonly scripts when possible.
-- For modifications, choose the minimal change and avoid anything that could harm stability or security.
-- Describe what each script does in the description.
-- Do not fetch content from the internet; use only configured repositories if installing software.
-- Bash scripts run with `set -euo pipefail`; handle expected non-zero exits explicitly.
-- Prefer Bash for a few shell commands and Python when logic is more involved.
-
-## Behavior
-
-- **Remote execution:** Every tool accepts an optional `host` argument. When set, the work runs on that host over SSH instead of locally.
-- **Containers:** If the `container` environment variable is set, tools refuse to run locally; a remote `host` must be used.
-- **Read-only vs destructive:** run_script_readonly is marked read-only; the modify script tool is marked destructive.
-- **Log file access:** requires explicit allowlist configuration via LINUX_MCP_ALLOWED_LOG_PATHS
-- **Service names:** automatically append '.service' suffix if not provided
-- **File paths:** must be absolute
-"""
-
-INSTRUCTIONS_VALIDATE_SCRIPT = """You have access to tools that validate and execute Python or Bash scripts you supply on the target system, for inspection or for making changes.
+INSTRUCTIONS_RUN_SCRIPT = """You have access to tools that validate and execute Python or Bash scripts you supply on the target system, for inspection or for making changes.
 You must validate a script before it will be allowed to run.
 
 ## Script tools
@@ -95,7 +69,7 @@ You must validate a script before it will be allowed to run.
 
 1. Call validate_script with your script and set readonly appropriately.
 2. Check the needs_confirmation field in the response.
-3. If needs_confirmation is false, call run_script with the same parameters and the token.
+3. If needs_confirmation is false, call run_script with the token.
 4. If needs_confirmation is true, call run_script_with_confirmation with the same parameters and the token.
 
 ## Usage
@@ -133,12 +107,22 @@ These tools map to six areas:
 
 ## Script tools
 
-- **run_script_readonly:** Run a Python or Bash script that only inspects the system. Use for queries and data collection.
-- **run_script_modify:** Run a Python or Bash script that may change files or configuration. Use only when changes are required.
+- **validate_script:** Validate a Python or Bash script via an external gatekeeper for security and policy compliance. Returns a token and needs_confirmation flag.
+- **run_script:** Run a validated read-only script. Use when validate_script returned needs_confirmation: false.
+- **run_script_with_confirmation:** Run a validated script that modifies the system. Use when validate_script returned needs_confirmation: true.
 
-# Usage
+## Workflow
 
-- Prefer fixed commands over readonly scripts when possible.
+1. Call validate_script with your script and set readonly appropriately.
+2. Check the needs_confirmation field in the response.
+3. If needs_confirmation is false, call run_script with the token.
+4. If needs_confirmation is true, call run_script_with_confirmation with the same parameters and the token.
+
+## Usage
+
+- Prefer fixed commands over custom scripts when possible.
+- Set readonly to true if the script only reads the system state.
+- Set readonly to false if the script modifies files or settings.
 - For modifications, choose the minimal change and avoid anything that could harm stability or security.
 - Describe what each script does in the description.
 - Do not fetch content from the internet; use only configured repositories if installing software.
@@ -149,7 +133,6 @@ These tools map to six areas:
 
 - **Remote execution:** Every tool accepts an optional `host` argument. When set, the work runs on that host over SSH instead of locally.
 - **Containers:** If the `container` environment variable is set, tools refuse to run locally; a remote `host` must be used.
-- **Read-only vs destructive:** Tools that only inspect are marked read-only; the modify script tool is marked destructive.
 - **Log file access:** requires explicit allowlist configuration via LINUX_MCP_ALLOWED_LOG_PATHS
 - **Service names:** automatically append '.service' suffix if not provided
 - **File paths:** must be absolute
@@ -165,9 +148,6 @@ match CONFIG.toolset:
     case Toolset.RUN_SCRIPT:
         instructions = INSTRUCTIONS_RUN_SCRIPT
         kwargs["include_tags"] = {"run_script"}
-    case Toolset.VALIDATE_SCRIPT:
-        instructions = INSTRUCTIONS_VALIDATE_SCRIPT
-        kwargs["include_tags"] = {"validate_script"}
     case Toolset.BOTH:
         instructions = INSTRUCTIONS_BOTH
     case _:
@@ -294,7 +274,7 @@ class DynamicDiscoveryMiddleware(Middleware):
                 instructions = session._init_options.instructions
                 if instructions:
                     session._init_options.instructions = instructions.replace(
-                        "run_script_modify", "run_script_modify_interactive"
+                        "run_script_with_confirmation", "run_script_interactive"
                     )
             else:
                 logger.warning("Unable to get ServerSession to update instructions for mcp-apps")

--- a/src/linux_mcp_server/tools/__init__.py
+++ b/src/linux_mcp_server/tools/__init__.py
@@ -14,9 +14,10 @@ from linux_mcp_server.tools.processes import list_processes
 from linux_mcp_server.tools.run_script import execute_script
 from linux_mcp_server.tools.run_script import get_execution_state
 from linux_mcp_server.tools.run_script import reject_script
-from linux_mcp_server.tools.run_script import run_script_modify
-from linux_mcp_server.tools.run_script import run_script_modify_interactive
-from linux_mcp_server.tools.run_script import run_script_readonly
+from linux_mcp_server.tools.run_script import run_script
+from linux_mcp_server.tools.run_script import run_script_interactive
+from linux_mcp_server.tools.run_script import run_script_with_confirmation
+from linux_mcp_server.tools.run_script import validate_script
 
 # services
 from linux_mcp_server.tools.services import get_service_logs
@@ -60,7 +61,8 @@ __all__ = [
     "read_file",
     "read_log_file",
     "reject_script",
-    "run_script_readonly",
-    "run_script_modify",
-    "run_script_modify_interactive",
+    "run_script",
+    "run_script_interactive",
+    "run_script_with_confirmation",
+    "validate_script",
 ]

--- a/src/linux_mcp_server/tools/run_script.py
+++ b/src/linux_mcp_server/tools/run_script.py
@@ -195,22 +195,7 @@ complexity such as elaborate logging or handling unlikely corner cases.
 """
 
 
-RUN_SCRIPT_READONLY_DESCRIPTION = (
-    """
-Run a script on a system in read-only mode.
-"""
-    + RUN_SCRIPT_COMMON_DESCRIPTION
-)
-
-
-RUN_SCRIPT_MODIFY_DESCRIPTION = (
-    """
-Run a script on a system to modify files or settings.
-"""
-    + RUN_SCRIPT_COMMON_DESCRIPTION
-)
-
-RUN_SCRIPT_MODIFY_INTERACTIVE = (
+RUN_SCRIPT_INTERACTIVE_DESCRIPTION = (
     """
 Run a script that modifies the system. The user will be asked for approval interactively.
 """
@@ -238,57 +223,6 @@ def _wrap_script(script_type: ScriptType, script: str) -> list[str]:
         script=shlex.quote((BASH_STRICT_PREAMBLE + script) if script_type == SCRIPT_TYPE_BASH else script),
     )
     return ["bash", "-c", wrapper_script]
-
-
-@mcp.tool(
-    tags={"run_script"},
-    title="Run script on system, read-only",
-    description=RUN_SCRIPT_READONLY_DESCRIPTION,
-    annotations=ToolAnnotations(readOnlyHint=True),
-)
-@log_tool_call
-@disallow_local_execution_in_containers
-async def run_script_readonly(
-    ctx: Context,
-    description: t.Annotated[
-        str,
-        Field(
-            description="Description of what the script does - e.g. 'Collect SELinux messages from the system logs.'"
-        ),
-    ],
-    script_type: t.Annotated[
-        ScriptType,
-        Field(description="The type of script to run (python or bash)."),
-    ],
-    script: t.Annotated[
-        str,
-        Field(description="The script to run."),
-    ],
-    host: Host = None,
-) -> str:
-    command = _wrap_script(script_type, script)
-
-    gatekeeper_result = check_run_script(
-        description,
-        script_type,
-        (BASH_STRICT_PREAMBLE + script) if script_type == SCRIPT_TYPE_BASH else script,
-        readonly=True,
-    )
-
-    match gatekeeper_result.status:
-        case GatekeeperStatus.OK:
-            pass
-        case GatekeeperStatus.MODIFIES_SYSTEM:
-            raise RuntimeError("Model returned MODIFIES_SYSTEM error for run_script_modify")
-        case _:
-            raise ToolError(gatekeeper_result.description)
-
-    returncode, stdout, stderr = await execute_command(command, host=host)
-    if returncode == 0:
-        stdout = stdout if isinstance(stdout, str) else stdout.decode("utf-8", errors="replace")
-        return stdout
-    else:
-        return f"Error executing script: return code {returncode}, stderr: {stderr}"
 
 
 @dataclass
@@ -349,15 +283,15 @@ async def reject_script(
 
 @mcp.tool(
     tags={"run_script", "mcp_apps_only"},
-    title="Propose to run a script that modifies system",
-    description=RUN_SCRIPT_MODIFY_INTERACTIVE,
+    title="Run a script with interactive user confirmation",
+    description=RUN_SCRIPT_INTERACTIVE_DESCRIPTION,
     annotations=ToolAnnotations(destructiveHint=True),
     output_schema=RunScriptInteractiveResult.model_json_schema(),
     meta={"ui": {"resourceUri": RUN_SCRIPT_APP_URI}},
 )
 @log_tool_call
 @disallow_local_execution_in_containers
-async def run_script_modify_interactive(
+async def run_script_interactive(
     ctx: Context,
     description: t.Annotated[
         str,
@@ -373,79 +307,52 @@ async def run_script_modify_interactive(
         str,
         Field(description="The script to run."),
     ],
+    readonly: t.Annotated[bool, Field(description="Should be true if the script does not modify the system.")],
+    token: t.Annotated[str, Field(description="The token returned by the validate_script tool.")],
     host: Host = None,
 ) -> ToolResult:
-    gatekeeper_result = check_run_script(description, script_type, script, readonly=False)
-    content: list[ContentBlock] | None = None
+    script_details = script_store.get_script_details(token)
 
-    if gatekeeper_result.status == GatekeeperStatus.OK:
-        content = [
-            TextContent(
-                type="text",
-                text="The user has been asked for approval; please respond nothing to the user yet; the final result will be provided as a separate message later.",
-            )
-        ]
+    # Verify that this script requires confirmation
+    if not script_details.needs_confirmation:
+        raise ToolError("This script does not require confirmation. Use run_script instead of run_script_interactive.")
 
-    # Initialize execution detail to keep execution status persistent
-    # Store script and script_type so set_script_approval can retrieve them by id
-    id = script_store.add_script(description, script, script_type, host, readonly=False)
-
-    if gatekeeper_result.status != GatekeeperStatus.OK:
-        script_store.set_script_state(id, "rejected-gatekeeper")
-
-    structured_content_obj = RunScriptInteractiveResult(
-        id=id, status=gatekeeper_result.status, detail=gatekeeper_result.detail
+    # Check if the passed parameters match the stored script details
+    new_details = ScriptDetails(
+        state="waiting-approval",
+        description=description,
+        script_type=script_type,
+        script=script,
+        host=host,
+        readonly=readonly,
     )
 
-    result = ToolResult(content=content, structured_content=structured_content_obj.model_dump())
+    result_id = token
+    if new_details != script_details:
+        # Parameters don't match - revalidate and create a new script store entry
+        gatekeeper_result = check_run_script(
+            description,
+            script_type,
+            (BASH_STRICT_PREAMBLE + script) if script_type == SCRIPT_TYPE_BASH else script,
+            readonly=readonly,
+        )
+        if gatekeeper_result.status != GatekeeperStatus.OK:
+            script_store.set_script_state(token, "rejected-gatekeeper")
+            raise ToolError(gatekeeper_result.description)
 
-    return result
+        # Create new script store entry with the updated parameters
+        result_id = script_store.add_script(description, script, script_type, host, readonly)
 
+    content: list[ContentBlock] = [
+        TextContent(
+            type="text",
+            text="The user has been asked for approval; please respond nothing to the user yet; the final result will be provided as a separate message later.",
+        )
+    ]
 
-@mcp.tool(
-    tags={"run_script", "mcp_apps_exclude"},
-    title="Run script to modify system",
-    description=RUN_SCRIPT_MODIFY_DESCRIPTION,
-    annotations=ToolAnnotations(destructiveHint=True),
-)
-@log_tool_call
-@disallow_local_execution_in_containers
-async def run_script_modify(
-    ctx: Context,
-    description: t.Annotated[
-        str,
-        Field(
-            description="Description of what the script does - e.g. 'Modify file permissions on nginx.conf to fix startup errors.'"
-        ),
-    ],
-    script_type: t.Annotated[
-        ScriptType,
-        Field(description="The type of script to run (python or bash)."),
-    ],
-    script: t.Annotated[
-        str,
-        Field(description="The script to run."),
-    ],
-    host: Host = None,
-) -> str:
-    command = _wrap_script(script_type, script)
+    structured_content_obj = RunScriptInteractiveResult(id=result_id, status=GatekeeperStatus.OK, detail="")
 
-    gatekeeper_result = check_run_script(
-        description,
-        script_type,
-        (BASH_STRICT_PREAMBLE + script) if script_type == SCRIPT_TYPE_BASH else script,
-        readonly=False,
-    )
-
-    if gatekeeper_result.status != GatekeeperStatus.OK:
-        raise ToolError(gatekeeper_result.description)
-
-    returncode, stdout, stderr = await execute_command(command, host=host)
-    if returncode == 0:
-        stdout = stdout if isinstance(stdout, str) else stdout.decode("utf-8", errors="replace")
-        return stdout
-    else:
-        return f"Error executing script: return code {returncode}, stderr: {stderr}"
+    return ToolResult(content=content, structured_content=structured_content_obj.model_dump())
 
 
 @mcp.tool(
@@ -462,7 +369,7 @@ async def get_execution_state(id: str):
 
 
 @mcp.tool(
-    tags={"validate_script"},
+    tags={"run_script"},
     title="Validate a script",
     description="Request validation of a script from the gatekeeper. The tool will return a unique token that must be included in the run_script tool call.",
 )
@@ -511,25 +418,75 @@ async def validate_script(
     return result
 
 
-async def _run_validated_script(
-    token: str,
-    description: str,
-    script_type: ScriptType,
-    script: str,
-    readonly: bool,
-    host: Host,
-    expect_confirmation: bool,
+@mcp.tool(
+    tags={"run_script"},
+    title="Run a script",
+    description="Call this tool to run a previously validated script. Use this when validate_script returned needs_confirmation: false.",
+    annotations=ToolAnnotations(readOnlyHint=True),
+)
+@log_tool_call
+@disallow_local_execution_in_containers
+async def run_script(
+    ctx: Context,
+    token: t.Annotated[str, Field(description="The token returned by the validate_script tool.")],
 ) -> str:
-    """Common implementation for run_script and run_script_with_confirmation."""
     script_details = script_store.get_script_details(token)
 
-    # Verify confirmation expectation matches
-    if expect_confirmation and not script_details.needs_confirmation:
+    # Verify that this script doesn't require confirmation
+    if script_details.needs_confirmation:
+        raise ToolError("This script requires confirmation. Use run_script_with_confirmation instead of run_script.")
+
+    script_store.set_script_state(token, "executing")
+    try:
+        command = _wrap_script(script_details.script_type, script_details.script)
+        returncode, stdout, stderr = await execute_command(command, host=script_details.host)
+    except Exception:
+        script_store.set_script_state(token, "failure")
+        raise
+
+    if returncode == 0:
+        script_store.set_script_state(token, "success")
+        return stdout if isinstance(stdout, str) else stdout.decode("utf-8", errors="replace")
+    else:
+        script_store.set_script_state(token, "failure")
+        return f"Error executing script: return code {returncode}, stderr: {stderr}"
+
+
+@mcp.tool(
+    tags={"run_script", "mcp_apps_exclude"},
+    title="Run a script with confirmation",
+    description="Call this tool to run a previously validated script that modifies the system. Use this when validate_script returned needs_confirmation: true. The parameters must match those passed to validate_script.",
+    annotations=ToolAnnotations(destructiveHint=True),
+)
+@log_tool_call
+@disallow_local_execution_in_containers
+async def run_script_with_confirmation(
+    ctx: Context,
+    description: t.Annotated[
+        str,
+        Field(
+            description="Description of what the script does - e.g. 'Modify file permissions on nginx.conf to fix startup errors.'"
+        ),
+    ],
+    script_type: t.Annotated[
+        ScriptType,
+        Field(description="The type of script to run (python or bash)."),
+    ],
+    script: t.Annotated[
+        str,
+        Field(description="The script to run."),
+    ],
+    readonly: t.Annotated[bool, Field(description="Should be true if the script does not modify the system.")],
+    token: t.Annotated[str, Field(description="The token returned by the validate_script tool.")],
+    host: Host = None,
+) -> str:
+    script_details = script_store.get_script_details(token)
+
+    # Verify that this script requires confirmation
+    if not script_details.needs_confirmation:
         raise ToolError(
             "This script does not require confirmation. Use run_script instead of run_script_with_confirmation."
         )
-    if not expect_confirmation and script_details.needs_confirmation:
-        raise ToolError("This script requires confirmation. Use run_script_with_confirmation instead of run_script.")
 
     # Verify the retrieved script details match the incoming parameters
     new_details = ScriptDetails(
@@ -567,69 +524,3 @@ async def _run_validated_script(
     else:
         script_store.set_script_state(token, "failure")
         return f"Error executing script: return code {returncode}, stderr: {stderr}"
-
-
-@mcp.tool(
-    tags={"validate_script"},
-    title="Run a script",
-    description="Call this tool to run a previously validated script. Use this when validate_script returned needs_confirmation: false. The parameters must match those passed to validate_script.",
-    annotations=ToolAnnotations(readOnlyHint=True),
-)
-@log_tool_call
-@disallow_local_execution_in_containers
-async def run_script(
-    ctx: Context,
-    description: t.Annotated[
-        str,
-        Field(
-            description="Description of what the script does - e.g. 'Collect SELinux messages from the system logs.'"
-        ),
-    ],
-    script_type: t.Annotated[
-        ScriptType,
-        Field(description="The type of script to run (python or bash)."),
-    ],
-    script: t.Annotated[
-        str,
-        Field(description="The script to run."),
-    ],
-    readonly: t.Annotated[bool, Field(description="Should be true if the script does not modify the system.")],
-    token: t.Annotated[str, Field(description="The token returned by the validate_script tool.")],
-    host: Host = None,
-) -> str:
-    return await _run_validated_script(
-        token, description, script_type, script, readonly, host, expect_confirmation=False
-    )
-
-
-@mcp.tool(
-    tags={"validate_script", "mcp_apps_exclude"},
-    title="Run a script with confirmation",
-    description="Call this tool to run a previously validated script that modifies the system. Use this when validate_script returned needs_confirmation: true. The parameters must match those passed to validate_script.",
-    annotations=ToolAnnotations(destructiveHint=True),
-)
-@log_tool_call
-@disallow_local_execution_in_containers
-async def run_script_with_confirmation(
-    ctx: Context,
-    description: t.Annotated[
-        str,
-        Field(
-            description="Description of what the script does - e.g. 'Modify file permissions on nginx.conf to fix startup errors.'"
-        ),
-    ],
-    script_type: t.Annotated[
-        ScriptType,
-        Field(description="The type of script to run (python or bash)."),
-    ],
-    script: t.Annotated[
-        str,
-        Field(description="The script to run."),
-    ],
-    readonly: t.Annotated[bool, Field(description="Should be true if the script does not modify the system.")],
-    token: t.Annotated[str, Field(description="The token returned by the validate_script tool.")],
-    host: Host = None,
-) -> str:
-    return await _run_validated_script(
-        token, description, script_type, script, readonly, host, expect_confirmation=True
-    )


### PR DESCRIPTION
- Remove run_script_readonly and run_script_modify (deprecated)
- Rename run_script_modify_interactive to run_script_interactive
- run_script only takes token parameter
- run_script_interactive and run_script_with_confirmation take all parameters  (needed for UI display and approval visibility)
- On parameter mismatch, run_script_interactive creates new script store entry
- Remove VALIDATE_SCRIPT toolset enum, keep only RUN_SCRIPT
- Update McpAppToolParamsSchema with readonly field
- Update server instructions and docs/usage.md
