### PR TITLE
Disable builds for macOS with Python 3.14t

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -165,6 +165,17 @@ jobs:
             image:
               name: windows-2025
 
+          # tokenizer does not have 3.14t wheels available and it fails to build on macOS.
+          # Once https://github.com/huggingface/tokenizers/pull/1952 is merged,
+          # the wheels should be available and this can be reenabled.
+          - python-version: "3.14t"
+            image:
+              name: macos-15-intel
+
+          - python-version: "3.14t"
+            image:
+              name: macos-26
+
     permissions:
       contents: write
 


### PR DESCRIPTION
`tokenizer` does not provide Python 3.14t wheels for macOS and the build fails. Once the appropriate wheels are available from `tokenizer`, this build can be reenabled.

https://github.com/huggingface/tokenizers/pull/1952