### PR TITLE
chore: trigger CI validation for functional tests

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -82,7 +82,6 @@ jobs:
             --compose "$COMPOSE" \
             --tag BusinessUnit=rhel_sst_lightspeed@downstream \
             --plan "$PLAN" \
-            --xunit \
             --timeout 120
 
           echo "Functional tests finished!"


### PR DESCRIPTION
Original PR:  This is a fake commit only to validate functional test ci works as intended. 

UPD: CI failed pointing to the obsolete tmt flag. This PR now removes it.