### PR TITLE
ci: add GitHub-GitLab PR mirroring integration

### DIFF
--- a/.github/workflows/gitlab-trigger.yml
+++ b/.github/workflows/gitlab-trigger.yml
@@ -1,0 +1,36 @@
+name: GitLab Trigger Comment
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  post-gitlab-link:
+    name: Post GitLab Trigger Link
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add GitLab trigger comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const commitSha = context.payload.pull_request.head.sha;
+            const shortSha = commitSha.substring(0, 7);
+
+            const gitlabUrl = new URL('https://gitlab.cee.redhat.com/rhel-lightspeed/mcp/linux-mcp-server/-/pipelines/new');
+            gitlabUrl.searchParams.set('ref', 'main');
+            gitlabUrl.searchParams.set('var[GITHUB_PR_NUMBER]', prNumber.toString());
+            gitlabUrl.searchParams.set('var[GITHUB_COMMIT_SHA]', commitSha);
+
+            const body = `For team members: [test commit \`${shortSha}\` in internal GitLab](${gitlabUrl.toString()})`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: body
+            });

--- a/.github/workflows/gitlab-trigger.yml
+++ b/.github/workflows/gitlab-trigger.yml
@@ -1,7 +1,7 @@
 name: GitLab Trigger Comment
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,31 @@
+# GitLab CI configuration for GitHub PR mirroring
+# This pipeline is manually triggered to create MRs from GitHub PRs for internal testing
+#
+# Required CI/CD Variable:
+#   GITLAB_TOKEN - Personal/Project Access Token with 'write_repository' scope
+#                  Configure at: Settings > CI/CD > Variables (Protected + Masked)
+
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+      when: always
+    - when: never
+
+variables:
+  GITHUB_PR_NUMBER:
+    description: "GitHub PR number to mirror"
+  GITHUB_COMMIT_SHA:
+    description: "GitHub commit SHA to fetch"
+
+stages:
+  - mirror
+
+mirror-github-pr:
+  stage: mirror
+  image: registry.access.redhat.com/ubi10-minimal
+  before_script:
+    - microdnf install -y jq git-core
+  script:
+    - bash scripts/mirror_github_pr.sh
+  rules:
+    - if: $GITHUB_PR_NUMBER && $GITHUB_COMMIT_SHA

--- a/scripts/mirror_github_pr.sh
+++ b/scripts/mirror_github_pr.sh
@@ -54,10 +54,6 @@ fi
 echo "PR Title: $PR_TITLE"
 echo "PR URL: $PR_URL"
 
-# Configure git
-git config --global user.email "ci@gitlab.cee.redhat.com"
-git config --global user.name "GitLab CI"
-
 # Clone from GitLab (has shared history), then fetch PR commit from GitHub
 echo "Cloning from GitLab..."
 git clone "$GITLAB_REMOTE" repo

--- a/scripts/mirror_github_pr.sh
+++ b/scripts/mirror_github_pr.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Mirror a GitHub PR to GitLab as a merge request.
+#
+# This script is designed to run in GitLab CI to create MRs from GitHub PRs
+# for internal testing. It fetches the PR metadata from GitHub, pushes the
+# commit to a branch in GitLab, and creates a merge request using push options.
+#
+# Required environment variables:
+#   GITHUB_PR_NUMBER  - The GitHub PR number to mirror
+#   GITHUB_COMMIT_SHA - The commit SHA to fetch
+#   GITLAB_TOKEN      - GitLab access token with 'write_repository' scope
+#
+# Optional environment variables:
+#   GITHUB_REPO    - GitHub repository (default: rhel-lightspeed/linux-mcp-server)
+#   GITLAB_PROJECT - GitLab project path (default: rhel-lightspeed/mcp/linux-mcp-server)
+#   GITLAB_HOST    - GitLab hostname (default: gitlab.cee.redhat.com)
+
+set -euo pipefail
+
+: "${GITHUB_REPO:=rhel-lightspeed/linux-mcp-server}"
+: "${GITLAB_PROJECT:=rhel-lightspeed/mcp/linux-mcp-server}"
+: "${GITLAB_HOST:=gitlab.cee.redhat.com}"
+
+if [[ -z "${GITHUB_PR_NUMBER:-}" ]] || [[ -z "${GITHUB_COMMIT_SHA:-}" ]]; then
+    echo "ERROR: GITHUB_PR_NUMBER and GITHUB_COMMIT_SHA are required"
+    exit 1
+fi
+
+if [[ -z "${GITLAB_TOKEN:-}" ]]; then
+    echo "ERROR: GITLAB_TOKEN is required"
+    exit 1
+fi
+
+BRANCH_NAME="github-pr-${GITHUB_PR_NUMBER}"
+GITLAB_REMOTE="https://oauth2:${GITLAB_TOKEN}@${GITLAB_HOST}/${GITLAB_PROJECT}.git"
+
+# Fetch PR information from GitHub
+echo "Fetching PR #${GITHUB_PR_NUMBER} from GitHub..."
+PR_INFO=$(curl -sf "https://api.github.com/repos/${GITHUB_REPO}/pulls/${GITHUB_PR_NUMBER}")
+
+if [[ -z "$PR_INFO" ]]; then
+    echo "ERROR: Could not fetch PR #${GITHUB_PR_NUMBER} from GitHub"
+    exit 1
+fi
+
+PR_TITLE=$(echo "$PR_INFO" | jq -r '.title')
+PR_URL=$(echo "$PR_INFO" | jq -r '.html_url')
+
+if [[ "$PR_TITLE" == "null" ]] || [[ -z "$PR_TITLE" ]]; then
+    echo "ERROR: PR #${GITHUB_PR_NUMBER} not found or has no title"
+    exit 1
+fi
+
+echo "PR Title: $PR_TITLE"
+echo "PR URL: $PR_URL"
+
+# Configure git
+git config --global user.email "ci@gitlab.cee.redhat.com"
+git config --global user.name "GitLab CI"
+
+# Clone from GitLab (has shared history), then fetch PR commit from GitHub
+echo "Cloning from GitLab..."
+git clone "$GITLAB_REMOTE" repo
+cd repo
+
+echo "Fetching commit ${GITHUB_COMMIT_SHA:0:7} from GitHub..."
+git remote add github "https://github.com/${GITHUB_REPO}.git"
+git fetch github "$GITHUB_COMMIT_SHA"
+git checkout -b "$BRANCH_NAME" "$GITHUB_COMMIT_SHA"
+
+# Check if branch already exists in GitLab
+echo "Checking if branch ${BRANCH_NAME} exists in GitLab..."
+if git ls-remote --exit-code origin "refs/heads/${BRANCH_NAME}" >/dev/null 2>&1; then
+    # Branch exists - just push to update the MR
+    echo "Branch exists, updating..."
+    git push -f origin "$BRANCH_NAME"
+    echo "Updated branch ${BRANCH_NAME}"
+else
+    # Branch doesn't exist - create MR with push options
+    echo "Creating new branch and MR..."
+    MR_DESCRIPTION="This MR mirrors GitHub PR #${GITHUB_PR_NUMBER} for internal testing.\n\n- GitHub PR: ${PR_URL}\n- Commit: ${GITHUB_COMMIT_SHA}"
+
+    git push origin "$BRANCH_NAME" \
+        -o merge_request.create \
+        -o merge_request.target=main \
+        -o "merge_request.title=${PR_TITLE}" \
+        -o "merge_request.description=${MR_DESCRIPTION}" \
+        -o merge_request.remove_source_branch
+
+    echo "Created MR for branch ${BRANCH_NAME}"
+fi


### PR DESCRIPTION
Add workflow to help team members test GitHub PRs in the internal GitLab mirror. When a PR is opened or updated, a GitHub Action posts a comment with a link to trigger a GitLab pipeline that creates a corresponding MR.

- .github/workflows/gitlab-trigger.yml: Posts comment with GitLab link
- .gitlab-ci.yml: Manual pipeline to create MR from GitHub PR
- scripts/mirror_github_pr.sh: Script to fetch PR and create GitLab MR

Requires GITLAB_TOKEN CI variable with 'write_repository' scope in GitLab.