### PR TITLE
Constrain fakeredis due to incompatibility with pydocket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ dependencies = [
     "litellm>=1.80.16",
     "pydantic-settings >= 2.12.0",
     "pydantic >= 2.12.5",
+    # pydocket is incompatible with newer versions of fakeredis.
+    # This can be removed once pydocket releases a fix.
+    # https://github.com/chrisguidry/docket/issues/388
+    "fakeredis<2.35",
 ]
 dynamic = ["version"]
 license-files = ["LICENSE", "licenses/GPL-3.0.txt"]

--- a/uv.lock
+++ b/uv.lock
@@ -1937,6 +1937,7 @@ name = "linux-mcp-server"
 source = { editable = "." }
 dependencies = [
     { name = "asyncssh", extra = ["bcrypt"] },
+    { name = "fakeredis" },
     { name = "fastmcp" },
     { name = "litellm" },
     { name = "pydantic" },
@@ -1986,6 +1987,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "asyncssh", extras = ["bcrypt"], specifier = ">=2.22.0" },
+    { name = "fakeredis", specifier = "<2.35" },
     { name = "fastmcp", specifier = ">=2.14.4,<2.14.6" },
     { name = "google-cloud-aiplatform", marker = "extra == 'gcp'", specifier = ">=1.147.0" },
     { name = "gssapi", marker = "extra == 'gssapi'", specifier = ">=1.11.1" },


### PR DESCRIPTION
A recent release of fakeredis, which is a dependency of pydocket, causes linux-mcp-server to fail to start. Add a constraint to avoid the incompatible version of fakeredis.

https://github.com/chrisguidry/docket/issues/388