### PR TITLE
ci: use system default python for TMT plans

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,20 +1,23 @@
 summary: Functional linux-mcp-server testing
 
 .python_setup: &python_setup |
-  if dnf info python3.12 &>/dev/null; then
-      dnf install -y python3.12 python3.12-pip
-      PYTHON_CMD=python3.12
-  elif dnf info python3.11 &>/dev/null; then
-      dnf install -y python3.11 python3.11-pip
-      PYTHON_CMD=python3.11
-  else
-      dnf install -y python3-pip
-      PYTHON_CMD=python3
+  dnf install -y python3 python3-pip
+  PYTHON_CMD=python3
+
+  # If system python is < 3.10 (e.g. RHEL 9), fallback to installing a newer version
+  if ! $PYTHON_CMD -c "import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)" 2>/dev/null; then
+      for ver in 3.12 3.11; do
+          if dnf info python$ver &>/dev/null; then
+              dnf install -y python$ver python${ver}-pip || dnf install -y python$ver python3-pip
+              PYTHON_CMD=python$ver
+              break
+          fi
+      done
   fi
   # Install from the current directory (the repo under test)
   $PYTHON_CMD -m pip install .
   $PYTHON_CMD -m pip install -r tests/functional/requirements.txt
-  $PYTHON_CMD -m pip freeze | grep linux-mcp-server
+  $PYTHON_CMD -m pip freeze
 
 discover:
     how: fmf

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -14,6 +14,11 @@ summary: Functional linux-mcp-server testing
           fi
       done
   fi
+  # Create a dummy frontend dist directory and set a pretend version
+  # to satisfy hatchling/hatch-vcs build requirements in non-git environments
+  mkdir -p mcp-app/dist
+  export SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
+
   # Install from the current directory (the repo under test)
   $PYTHON_CMD -m pip install .
   $PYTHON_CMD -m pip install -r tests/functional/requirements.txt

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -17,7 +17,7 @@ from utils.shell import shell
 # --- Default configuration ---
 SERVER_COMMAND = "linux-mcp-server"
 SERVER_ARGS = []
-DEFAULT_SERVER_ENV = {"LINUX_MCP_LOG_LEVEL": "DEBUG"}
+DEFAULT_SERVER_ENV = {"LINUX_MCP_LOG_LEVEL": "INFO"}
 
 
 @contextlib.asynccontextmanager

--- a/tests/functional/pytest.ini
+++ b/tests/functional/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+# Force pytest-asyncio to use a single session-scoped event loop.
+# This prevents a cross-loop deadlock between the session-scoped MCP server
+# fixture and the async test functions in the latest pytest-asyncio version.
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = session
+asyncio_default_test_loop_scope = session

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -26,6 +26,7 @@ Pygments>=2.19.2
 PyJWT>=2.10.1
 pytest>=9.0.1
 pytest-asyncio>=1.3.0
+pytest-cov>=7.0.0
 python-dotenv>=1.2.1
 python-multipart>=0.0.20
 PyYAML>=6.0.3


### PR DESCRIPTION
This PR unblocks the Functional Tests CI pipeline by addressing several environment-related failures uncovered during the migration to Fedora 43 and latest dependency versions:

-  Updated TMT plans to use the system default Python version
-  Added a dummy frontend directory mcp-app and "pretend" versioning to satisfy hatchling requirements in the minimal, non-git TMT guest environment.
-  Added pytest-cov to functional requirements to properly handle coverage settings inherited from the root pyproject.toml.
-  Configured a dedicated pytest.ini for functional tests to force a session-scoped event loop, preventing hangs in recent pytest-asyncio versions.
-  Migrated derived fields (total, lines_count) in models.py to @computed_field. This fixes a fatal TypeError caused by dependency drift to Pydantic 2.13.0, which strictly enforces zero-argument default_factory callables. However, it's a bug workaround it seems. 

