### PR TITLE
ci: Add tag to the mirroring ci pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,8 @@ stages:
 mirror-github-pr:
   stage: mirror
   image: registry.access.redhat.com/ubi10-minimal
+  tags:
+    - rhel-lightspeed
   before_script:
     - microdnf install -y jq git-core
   script:


### PR DESCRIPTION
Add rhel-lightspeed tag to the github mirroring pipeline so it actually gets run by the group runner on gitlab.