### PR TITLE
fix: set temperature to zero for gatekeeper models

### DIFF
--- a/src/linux_mcp_server/gatekeeper/check_run_script.py
+++ b/src/linux_mcp_server/gatekeeper/check_run_script.py
@@ -197,7 +197,7 @@ def check_run_script(description: str, script_type: str, script: str, *, readonl
     else:
         response_format = None
 
-    response = completion(model=get_model(), messages=messages, response_format=response_format)
+    response = completion(model=get_model(), messages=messages, response_format=response_format, temperature=0)
     assert isinstance(response, ModelResponse)
     assert isinstance(response.choices[0], Choices)
     response_text = (response.choices[0].message.content or "").strip()


### PR DESCRIPTION
The temperature of all gatekeeper models should be set to zero. This minimizes output variance and mitigates the risk of adversarial prompt injections eliciting harmful behavior.