### PR TITLE
fix(run_script): set readOnlyHint for validate_script

### DIFF
--- a/src/linux_mcp_server/tools/run_script.py
+++ b/src/linux_mcp_server/tools/run_script.py
@@ -393,6 +393,7 @@ async def validate_script(
     ],
     host: Host = None,
     readonly: t.Annotated[bool, Field(description="Should be true if the script does not modify the system.")] = True,
+    annotations=ToolAnnotations(readOnlyHint=True),
 ) -> ToolResult:
     gatekeeper_result = check_run_script(
         description,


### PR DESCRIPTION
Setting readOnlyHint tells clients that this method will not change anything ... setting this hint correctly makes "smart" mode do what we want for goose.