### PR TITLE
fix(ssh): replace private _username with public get_extra_info API

### DIFF
--- a/src/linux_mcp_server/connection/ssh.py
+++ b/src/linux_mcp_server/connection/ssh.py
@@ -120,7 +120,11 @@ class SSHConnectionManager:
                 logger.debug(f"SSH_REUSE: {key} | pool_size={len(self._connections)}")
                 # Use audit log with connection reuse info
                 log_ssh_connect(
-                    host, username=conn._username, status=Status.success, reused=True, key_path=self._ssh_key
+                    host,
+                    username=conn.get_extra_info("username"),
+                    status=Status.success,
+                    reused=True,
+                    key_path=self._ssh_key,
                 )
                 return conn
             else:
@@ -156,7 +160,13 @@ class SSHConnectionManager:
             self._connections[key] = conn
 
             # Log successful connection using audit function
-            log_ssh_connect(host, username=conn._username, status=Status.success, reused=False, key_path=self._ssh_key)
+            log_ssh_connect(
+                host,
+                username=conn.get_extra_info("username"),
+                status=Status.success,
+                reused=False,
+                key_path=self._ssh_key,
+            )
 
             # DEBUG level: Log pool state
             logger.debug(f"SSH_POOL: add_connection | connections={len(self._connections)}")
@@ -234,7 +244,7 @@ class SSHConnectionManager:
                     },
                 )
                 raise ConnectionError(
-                    f"Command timed out after {timeout}s on {conn._username}@{host}: {cmd_str}"
+                    f"Command timed out after {timeout}s on {conn.get_extra_info('username')}@{host}: {cmd_str}"
                 ) from None
 
             return_code = result.exit_status if result.exit_status is not None else 0
@@ -315,14 +325,14 @@ async def get_remote_bin_path(
         result = await connection.run(shlex.join(["command", "-v", command]), timeout=timeout)
     except asyncssh.Error as err:
         raise ConnectionError(
-            f"Error when trying to locate command '{command}' on {connection._username}@{hostname}: {err}"
+            f"Error when trying to locate command '{command}' on {connection.get_extra_info('username')}@{hostname}: {err}"
         )
 
     if result.exit_status == 0 and result.stdout:
         stdout = result.stdout.decode() if isinstance(result.stdout, bytes) else result.stdout
         return stdout.strip()
 
-    raise FileNotFoundError(f"Unable to find command '{command}' on {connection._username}@{hostname}")
+    raise FileNotFoundError(f"Unable to find command '{command}' on {connection.get_extra_info('username')}@{hostname}")
 
 
 async def execute_command(

--- a/tests/connection/ssh/test_connection_manager.py
+++ b/tests/connection/ssh/test_connection_manager.py
@@ -6,7 +6,8 @@ from linux_mcp_server.connection.ssh import SSHConnectionManager
 
 @pytest.fixture
 def mock_connection(mocker):
-    mock_connection = mocker.AsyncMock(asyncssh.SSHClientConnection, name="connection", _username="testuser")
+    mock_connection = mocker.AsyncMock(asyncssh.SSHClientConnection, name="connection")
+    mock_connection.get_extra_info.return_value = "testuser"
     mock_connection.run.return_value = mocker.Mock(exit_status=0, stdout="remote output", stderr="")
     mock_connection.is_closed.return_value = False
 
@@ -55,8 +56,10 @@ async def test_get_connection_different_hosts(mocker, mock_asyncssh_connect):
     manager = SSHConnectionManager()
     manager._connections.clear()
 
-    mock_conn1 = mocker.AsyncMock(asyncssh.SSHClientConnection, return_value=False, _username="testuser")
-    mock_conn2 = mocker.AsyncMock(asyncssh.SSHClientConnection, return_value=False, _username="testuser")
+    mock_conn1 = mocker.AsyncMock(asyncssh.SSHClientConnection, return_value=False)
+    mock_conn1.get_extra_info.return_value = "testuser"
+    mock_conn2 = mocker.AsyncMock(asyncssh.SSHClientConnection, return_value=False)
+    mock_conn2.get_extra_info.return_value = "testuser"
 
     async def async_connect(*args, **kwargs):
         return mock_conn1 if kwargs.get("host") == "host1" else mock_conn2
@@ -135,12 +138,10 @@ async def test_close_connections(mocker, mock_asyncssh_connect):
     manager = SSHConnectionManager()
     manager._connections.clear()
 
-    mock_conn1 = mocker.AsyncMock(
-        asyncssh.SSHClientConnection, return_value=False, wait_closed=mocker.AsyncMock(), _username="testuser"
-    )
-    mock_conn2 = mocker.AsyncMock(
-        asyncssh.SSHClientConnection, return_value=False, wait_closed=mocker.AsyncMock(), _username="testuser"
-    )
+    mock_conn1 = mocker.AsyncMock(asyncssh.SSHClientConnection, return_value=False, wait_closed=mocker.AsyncMock())
+    mock_conn1.get_extra_info.return_value = "testuser"
+    mock_conn2 = mocker.AsyncMock(asyncssh.SSHClientConnection, return_value=False, wait_closed=mocker.AsyncMock())
+    mock_conn2.get_extra_info.return_value = "testuser"
 
     async def async_connect(*args, **kwargs):
         return mock_conn1 if kwargs.get("host") == "host1" else mock_conn2

--- a/tests/connection/ssh/test_get_bin_path.py
+++ b/tests/connection/ssh/test_get_bin_path.py
@@ -12,7 +12,8 @@ def test_get_bin_path_not_found(mocker):
 
 
 async def test_get_remote_bin_path_error(mocker):
-    connection = mocker.Mock(asyncssh.SSHClientConnection, _username="testuser")
+    connection = mocker.Mock(asyncssh.SSHClientConnection)
+    connection.get_extra_info.return_value = "testuser"
     connection.run = mocker.AsyncMock(side_effect=asyncssh.Error(1, "Raised intentionally"))
 
     with pytest.raises(ConnectionError, match="Raised intentionally"):
@@ -20,7 +21,8 @@ async def test_get_remote_bin_path_error(mocker):
 
 
 async def test_get_remote_bin_not_found(mocker):
-    connection = mocker.Mock(asyncssh.SSHClientConnection, _username="testuser")
+    connection = mocker.Mock(asyncssh.SSHClientConnection)
+    connection.get_extra_info.return_value = "testuser"
     connection.run = mocker.AsyncMock(return_value=mocker.Mock(exit_status=0, stdout="", stderr=""))
 
     with pytest.raises(FileNotFoundError, match="Unable to find command"):

--- a/tests/connection/ssh/test_timeout.py
+++ b/tests/connection/ssh/test_timeout.py
@@ -42,7 +42,8 @@ def ssh_manager():
 @pytest.fixture
 def mock_ssh_connection(mocker):
     """Provide a mock SSH connection with asyncssh.connect patched."""
-    mock_conn = Mock(spec=SSHClientConnection, _username="testuser")
+    mock_conn = Mock(spec=SSHClientConnection)
+    mock_conn.get_extra_info.return_value = "testuser"
     mock_conn.is_closed.return_value = False
 
     mock_connect = AsyncMock(spec=asyncssh.connect)


### PR DESCRIPTION
## Summary

Replace all usages of asyncssh's private `conn._username` attribute with the public `conn.get_extra_info("username")` API.

## Motivation

The codebase accesses `SSHClientConnection._username` in 5 places for audit logging and error messages. This is a private attribute (prefixed with `_`) that is not part of asyncssh's public API contract. While it works today, it could break on any future asyncssh release without notice.

asyncssh provides `get_extra_info("username")` as the [documented public API](https://asyncssh.readthedocs.io/en/latest/api.html#asyncssh.SSHClientConnection.get_extra_info) for retrieving the authenticated username. It returns the same value — verified to be the exact same object (`is` identity) in testing.

## Changes

**`src/linux_mcp_server/connection/ssh.py`** (5 replacements):
- Connection pool reuse audit log (L122)
- New connection audit log (L160)
- Command timeout error message (L244)
- `get_remote_bin_path()` SSH error message (L325)
- `get_remote_bin_path()` not-found error message (L330)

**Tests** (3 files, mock pattern updated):
```python
# Before: setting private attribute directly
Mock(SSHClientConnection, _username="testuser")

# After: mocking the public API
mock = Mock(SSHClientConnection)
mock.get_extra_info.return_value = "testuser"
```

## Verification

- `make verify` passes (ruff ✅, pyright ✅, 487 tests ✅)
- Manually verified `get_extra_info("username")` returns identical results to `_username` across multiple scenarios (explicit username, SSH config inferred username)
