### PR TITLE
run_script: Avoid requesting sudo password

### DIFF
--- a/src/linux_mcp_server/connection/ssh.py
+++ b/src/linux_mcp_server/connection/ssh.py
@@ -449,7 +449,13 @@ async def _execute_local(
     timeout = CONFIG.command_timeout
 
     try:
-        proc = await asyncio.create_subprocess_exec(*full_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc = await asyncio.create_subprocess_exec(
+            *full_command,
+            start_new_session=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         try:
             stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except asyncio.TimeoutError:


### PR DESCRIPTION
When running the MCP server over HTTP transport, `_wrap_script()` request the sudo password in the terminal.

Replace the current command to check if sudo fails with non-interactive mode. From the sudo help:

    non-interactive mode, no prompts are used

Also, replace `whoami` with `true`, which simply return successfully, from its man page:

    true - do nothing, successfully

Fixes: e6a05df580bc ("[RSPEED-2335] Wrap executed commands in sudo+systemd-run where possible (#256)")
Closes: https://github.com/rhel-lightspeed/linux-mcp-server/issues/414?reload=1

[RSPEED-2335]: https://redhat.atlassian.net/browse/RSPEED-2335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ