### PR TITLE
Call the generate_tool_docs script during doc workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,6 +52,9 @@ jobs:
           cd ..
           uv sync --locked --group docs
 
+      - name: Generate tool documentation
+        run: uv run --locked python scripts/generate_tool_docs.py
+
       - name: Build documentation
         run: uv run --locked mkdocs build --strict
 


### PR DESCRIPTION
The docs.yml workflow was not calling the `generate_tool_docs.py` script, so the documentation workflow was failing.