### PR TITLE
feat(ci): add evaluation workflow for gatekeeper models

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,27 +5,53 @@
 #   GITLAB_TOKEN - Personal/Project Access Token with 'write_repository' scope
 #                  Configure at: Settings > CI/CD > Variables (Protected + Masked)
 
-workflow:
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "web"
-      when: always
-    - when: never
-
 variables:
+  WORKFLOW:
+    description: "Select workflow for manual runs."
+    value: "mirror"
+    options:
+      - "mirror"
+      - "gatekeeper_eval"
   GITHUB_PR_NUMBER:
     description: "GitHub PR number to mirror"
   GITHUB_COMMIT_SHA:
     description: "GitHub commit SHA to fetch"
 
+# Define all possible stages globally so child files can just attach to them
 stages:
+  - setup
+  - eval
+  - post-eval
   - mirror
 
-mirror-github-pr:
-  stage: mirror
-  image: images.paas.redhat.com/it-cloud-ocp-proxy-lib/python:3.14
+default:
   tags:
     - rhel-lightspeed
-  script:
-    - python3 scripts/mirror_github_pr.py
+
+# The gitlab pipelines/new web UI does not work correctly if there are no jobs
+placeholder_job:
+  stage: setup
+  script: ["true"]
   rules:
-    - if: $GITHUB_PR_NUMBER && $GITHUB_COMMIT_SHA
+    - if: $WORKFLOW == "impossible_value"
+
+# ==========================================
+# ROUTER: Dynamically include child workflows
+# ==========================================
+include:
+  # 1. MIRRORING
+  - local: '.gitlab/ci/mirror.yml'
+    rules:
+      - if: $WORKFLOW == "mirror" || ($GITHUB_PR_NUMBER && $GITHUB_COMMIT_SHA)
+
+  # 2. GATEKEEPER EVAL
+  - local: '.gitlab/ci/eval-gatekeeper.yml'
+    rules:
+      # Trigger A: Manual selection from UI
+      - if: $WORKFLOW == "gatekeeper_eval"
+      # Trigger B: Automated MR or Push, BUT only if specific files changed
+      - if: '!$WORKFLOW && ($CI_PIPELINE_SOURCE == "merge_request_event" || $CI_PIPELINE_SOURCE == "push")'
+        changes:
+          - "eval/gatekeeper/**/*"
+          - "src/linux_mcp_server/gatekeeper/**/*"
+

--- a/.gitlab/ci/eval-gatekeeper.yml
+++ b/.gitlab/ci/eval-gatekeeper.yml
@@ -1,0 +1,98 @@
+# ==========================================
+# EVAL WORKFLOW - SETUP
+# ==========================================
+setup-uv-and-mcp-apps:
+  stage: setup
+  image: images.paas.redhat.com/it-cloud-ocp-proxy-lib/python:3.14
+  variables:
+    HOME: "$CI_PROJECT_DIR"
+  script:
+    # Install uv
+    - export PYTHONUSERBASE=$CI_PROJECT_DIR/.local
+    - pip install --user uv
+
+    # Install nvm to set up node and npm
+    - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
+    - \. "$HOME/.nvm/nvm.sh"
+    - nvm install 24
+
+    # Generate the bundled html file
+    - cd mcp-app && npm install && npm run build:prod
+  artifacts:
+    paths:
+      - .local/
+      - mcp-app/dist/
+    expire_in: 1 hour
+
+# ==========================================
+# EVAL WORKFLOW - TEMPLATES
+# ==========================================
+# Base template for all eval jobs
+.eval-base:
+  stage: eval
+  image: images.paas.redhat.com/it-cloud-ocp-proxy-lib/python:3.14
+  needs:
+    - job: setup-uv-and-mcp-apps
+      artifacts: true
+  before_script:
+    - export PATH="$CI_PROJECT_DIR/.local/bin:$PATH"
+    - uv sync --locked
+    - mkdir -p "$CI_PROJECT_DIR/data"
+    - export SSL_CERT_FILE="$CI_PROJECT_DIR/cert.pem"
+    - cp /etc/ssl/certs/ca-certificates.crt $SSL_CERT_FILE
+    - curl https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem >> $SSL_CERT_FILE
+  artifacts:
+    paths: 
+      - data/
+    expire_in: 1 hour
+
+# ==========================================
+# EVAL WORKFLOW - JOBS
+# ==========================================
+gatekeeper-eval-claude-4.6-opus: 
+  extends: .eval-base
+  variables:
+    MODEL_NAME: "claude-4.6-opus"
+  script:
+    - export LINUX_MCP_GATEKEEPER_MODEL="openrouter/anthropic/$MODEL_NAME"
+    - uv run eval/gatekeeper/run-eval.py --all -f json --output-all -o "$CI_PROJECT_DIR/data/$MODEL_NAME.json"
+  rules:
+    - if: $OPENROUTER_API_KEY
+
+gatekeeper-eval-models-corp-gemini:
+  extends: .eval-base
+  variables:
+    MODEL_NAME: "gemini-3.1-pro-preview"
+  script:
+    - export OPENAI_API_KEY="$MODELS_CORP_GEMINI_API_KEY"
+    - export MODEL="$MODEL_NAME"
+    - ./eval/gatekeeper/run-eval-models-corp.sh --all -f json --output-all -o "$CI_PROJECT_DIR/data/$MODEL_NAME.json"
+  rules:
+    - if: $MODELS_CORP_GEMINI_API_KEY
+
+gatekeeper-eval-models-corp-gpt-oss-20b:
+  extends: .eval-base
+  variables:
+    MODEL_NAME: "gpt-oss-20b"
+  script:
+    - export OPENAI_API_KEY="$MODELS_CORP_GPT_OSS_20B_API_KEY"
+    - export MODEL="openai/$MODEL_NAME"
+    - ./eval/gatekeeper/run-eval-models-corp.sh --all -f json --output-all -o "$CI_PROJECT_DIR/data/$MODEL_NAME.json"
+  rules:
+    - if: $MODELS_CORP_GPT_OSS_20B_API_KEY
+
+# ==========================================
+# EVAL WORKFLOW - POST-EVAL
+# ==========================================
+post-eval-result:
+  stage: post-eval
+  image: images.paas.redhat.com/it-cloud-ocp-proxy-lib/bash
+  script:
+    - cp eval/gatekeeper/index.html "$CI_PROJECT_DIR/index.html"
+
+      # Create the manifest file for the rendering app to correctly gather the data
+    - ls data/*.json | xargs -n1 basename > data/manifest.txt
+  artifacts:
+    paths:
+      - data/
+      - index.html

--- a/.gitlab/ci/mirror.yml
+++ b/.gitlab/ci/mirror.yml
@@ -1,0 +1,5 @@
+mirror-github-pr:
+  stage: mirror
+  image: images.paas.redhat.com/it-cloud-ocp-proxy-lib/python:3.14
+  script:
+    - python3 scripts/mirror_github_pr.py


### PR DESCRIPTION
- Introduce GitLab CI inputs to toggle between 'mirror' and 'eval' workflows.
- Add 'setup' stage to install uv, nvm, and build the MCP app.
- Add 'eval' stage with jobs for target gatekeeper models.
- Implement 'post-eval' stage to aggregate results and prepare an HTML report.
- Configure Red Hat internal certificate handling for corp model endpoints.