### PR TITLE
fix mcp-apps(ui): correct horizontal overflow in code blocks

### DIFF
--- a/mcp-app/src/global.css
+++ b/mcp-app/src/global.css
@@ -75,11 +75,17 @@
   }
 
   .code-block {
-    @apply bg-app-bg-secondary text-app-fg-secondary rounded-lg p-4 font-mono text-sm relative;
+    @apply font-mono text-sm relative;
   }
 
   .code-block .language-label {
     @apply absolute top-2 right-2 text-app-fg-tertiary text-xs;
+  }
+
+  .code-block pre {
+    @apply overflow-x-auto bg-app-bg-secondary text-app-fg-secondary rounded-lg p-4;
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-app-fg-secondary) transparent;
   }
 
   .status-allowed {


### PR DESCRIPTION
Moved the background, padding, and border-radius styles from the `.code-block` wrapper to the inner `<pre>` element and added `overflow-x-auto`.

Previously, long lines of code without line breaks caused the entire parent container to overflow, breaking the layout. This change ensures that horizontal scrolling is properly contained within the code block itself.

## Before this patch

https://github.com/user-attachments/assets/e608b529-cba2-431a-a466-d5569078f176

## After this patch

https://github.com/user-attachments/assets/eb9ea644-ed30-4ade-a25f-270d859f9556




