### PR TITLE
fix(scripts): extend timeout in verify_installation.sh

### DIFF
--- a/scripts/verify_installation.sh
+++ b/scripts/verify_installation.sh
@@ -20,7 +20,7 @@ verify_server_startup() {
   SERVER_PID=$!
 
   # Wait for log message
-  if timeout 20s grep -q "Running Linux MCP Server" <(tail -f "$log_file"); then
+  if timeout 300s grep -q "Running Linux MCP Server" <(tail -f "$log_file"); then
     echo "$method_name server successfully initialized and logged startup message."
     kill $SERVER_PID
     exit 0


### PR DESCRIPTION
- Increased the log tailing timeout from 20s to 300s.
- Allows `uvx` to pass the installation test.
- Prevents timeouts caused by `uvx` needing extra time at startup to resolve and install dependencies on the fly.