### PR TITLE
fix(eval): handle exceptions in gatekeeper benchmark

### DIFF
--- a/eval/gatekeeper/index.html
+++ b/eval/gatekeeper/index.html
@@ -187,11 +187,13 @@
       }
 
       function compareResult(expectedResult, actualResult) {
-        if (expectedResult === actualResult) {
+        if ("exception" in actualResult) return "exception";
+
+        if (expectedResult.status === actualResult.status) {
           return "same";
-        } else if (expectedResult === "OK") {
+        } else if (expectedResult.status === "OK") {
           return "ok_to_forbidden";
-        } else if (actualResult === "OK") {
+        } else if (actualResult.status === "OK") {
           return "forbidden_to_ok";
         } else {
           return "other_mismatch";
@@ -306,7 +308,6 @@
               const entry = combinedResult[model][testCase];
               const thisCell = document.createElement("td");
 
-              // Deal with missing test results because of exception during eval
               if (!entry) {
                 thisCell.textContent = "missing";
                 thisCell.classList.add("missing");
@@ -315,8 +316,8 @@
               }
 
               const comparison = compareResult(
-                entry.expected_result.status,
-                entry.result.status,
+                entry.expected_result,
+                entry.result,
               );
               thisCell.textContent = comparison;
               thisCell.classList.add(setClassForComparison(comparison));


### PR DESCRIPTION
Update compareResult to accept full result objects instead of just status strings, enabling early detection of exception entries. Remove a redundant comment for missing test results.

---

This patch addresses problem 3 mentioned in https://github.com/rhel-lightspeed/linux-mcp-server/pull/450