### PR TITLE
fix(gatekeeper): suppress litellm debugging message

### DIFF
--- a/src/linux_mcp_server/gatekeeper/check_run_script.py
+++ b/src/linux_mcp_server/gatekeeper/check_run_script.py
@@ -1,5 +1,7 @@
 import logging
 
+import litellm
+
 from litellm import Choices
 from litellm import completion
 from litellm import get_supported_openai_params
@@ -8,6 +10,13 @@ from pydantic import BaseModel
 
 from linux_mcp_server.config import CONFIG
 from linux_mcp_server.utils import StrEnum
+
+
+# LiteLLM has bugs where the custom_llm_provider is not properly
+# passed back into query functions for things like "model supports reasoning".
+# Without this, each such failure spits out a debug message to the terminal
+# https://github.com/BerriAI/litellm/issues/23879
+litellm.suppress_debug_info = True
 
 
 logger = logging.getLogger("linux-mcp-server")


### PR DESCRIPTION
LiteLLM has bugs where the custom_llm_provider is not properly passed back into query functions for things like "model supports reasoning". Set 'litellm.suppress_debug_info = True' to suppress debug messages - these aren't *our* bugs.

https://github.com/BerriAI/litellm/issues/23879