### PR TITLE
test(functional): Add '--skip-summary' to the testing-farm command line

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -128,6 +128,8 @@ jobs:
           PLAN: general
         run: |
           echo "Starting functional tests..."
+          # --skip-summary is needed because outside the Red Hat VPN, we
+          # don't have access to artifact storage.
           podman run --rm \
             -e TESTING_FARM_API_TOKEN="$TESTING_FARM_API_TOKEN" \
             quay.io/testing-farm/cli testing-farm request \
@@ -137,4 +139,5 @@ jobs:
             --compose "$COMPOSE" \
             --tag "BusinessUnit=rhel_sst_lightspeed@downstream" \
             --plan "$PLAN" \
-            --timeout 120
+            --timeout 120 \
+            --skip-summary


### PR DESCRIPTION
Generating the summary table requires access to the artifact storage for Testing Farm, which for the Red Hat ranch requires being on the Red Hat. As of recently, failures started being fatal, and an explicit --skip-summary is needed.

I haven't tested this, but from conversation on the #testing-farm Slack channel, this seems to be the right fix for recent failures, like:

https://github.com/rhel-lightspeed/linux-mcp-server/actions/runs/26107359758