### PR TITLE
Use commit status to improve github/gitlab integration

### DIFF
--- a/.github/workflows/gitlab-trigger.yml
+++ b/.github/workflows/gitlab-trigger.yml
@@ -1,36 +1,36 @@
-name: GitLab Trigger Comment
+name: GitLab Mirror Status
 
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
-  pull-requests: write
+  statuses: write
 
 jobs:
-  post-gitlab-link:
-    name: Post GitLab Trigger Link
+  set-gitlab-status:
+    name: Set GitLab Mirror Status
     runs-on: ubuntu-latest
 
     steps:
-      - name: Add GitLab trigger comment
+      - name: Create pending commit status
         uses: actions/github-script@v9
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
             const commitSha = context.payload.pull_request.head.sha;
-            const shortSha = commitSha.substring(0, 7);
 
             const gitlabUrl = new URL('https://gitlab.cee.redhat.com/rhel-lightspeed/mcp/linux-mcp-server/-/pipelines/new');
             gitlabUrl.searchParams.set('ref', 'main');
             gitlabUrl.searchParams.set('var[GITHUB_PR_NUMBER]', prNumber.toString());
             gitlabUrl.searchParams.set('var[GITHUB_COMMIT_SHA]', commitSha);
 
-            const body = `For team members: [test commit \`${shortSha}\` in internal GitLab](${gitlabUrl.toString()})`;
-
-            await github.rest.issues.createComment({
+            await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: prNumber,
-              body: body
+              sha: commitSha,
+              state: 'pending',
+              target_url: gitlabUrl.toString(),
+              description: 'Click Details to trigger internal testing',
+              context: 'gitlab / mirror'
             });

--- a/.gitlab/ci/CREDENTIALS.md
+++ b/.gitlab/ci/CREDENTIALS.md
@@ -13,6 +13,14 @@ These are configured in **Settings > CI/CD > Variables** on the GitLab project.
 - **Type:** Personal or Project Access Token with `write_repository` scope.
 - **How to create:** GitLab > Settings > Access Tokens > create a token with `write_repository`. Then add it as a CI/CD variable (Protected + Masked).
 
+### `GITHUB_STATUS_TOKEN`
+
+- **Used by:** `mirror.yml` (PR mirroring workflow)
+- **Purpose:** Posts a commit status back to the GitHub PR after a successful mirror, so the PR checks tab shows the mirroring result with a link to the GitLab MR.
+- **Type:** GitHub Personal Access Token — classic PAT with `repo:status` scope, or fine-grained PAT with "Commit statuses: Write" permission on the target repository.
+- **How to create:** GitHub > Settings > Developer settings > Personal access tokens > create a token with the appropriate scope. Then add it as a CI/CD variable in GitLab (Protected + Masked).
+- **Optional:** If not configured, the mirror script still functions but skips posting the GitHub commit status.
+
 ### `MODELS_CORP_*_API_KEY`
 
 - **Used by:** `eval-gatekeeper.yml` (models.corp eval jobs)

--- a/.gitlab/ci/mirror.yml
+++ b/.gitlab/ci/mirror.yml
@@ -2,4 +2,6 @@ mirror-github-pr:
   stage: mirror
   image: images.paas.redhat.com/it-cloud-ocp-proxy-lib/python:3.14
   script:
+    - export MIRROR_START_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     - python3 scripts/mirror_github_pr.py
+    - '[ -z "$GITHUB_STATUS_TOKEN" ] || python3 scripts/report_konflux_status.py'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ tag-only = [
 
 [tool.pyright]
 include = [
+    "scripts",
     "src",
     "tests",
 ]

--- a/scripts/generate_tool_docs.py
+++ b/scripts/generate_tool_docs.py
@@ -17,6 +17,8 @@ import textwrap
 from collections import defaultdict
 from pathlib import Path
 
+from fastmcp.tools import FunctionTool
+
 
 # Module name → (display order, heading, filename slug, description)
 MODULE_CATEGORIES: dict[str, tuple[int, str, str, str]] = {
@@ -388,7 +390,9 @@ async def main():
         if tool.tags & HIDDEN_TAGS:
             continue
 
-        module = getattr(tool.fn, "__module__", "unknown")
+        module = "unknown"
+        if isinstance(tool, FunctionTool):
+            module = getattr(tool.fn, "__module__", "unknown")
         groups[module].append(tool)
 
     # Sort groups by defined order

--- a/scripts/mirror_github_pr.py
+++ b/scripts/mirror_github_pr.py
@@ -12,9 +12,10 @@ Required environment variables:
   GITLAB_TOKEN      - GitLab access token with 'write_repository' scope
 
 Optional environment variables:
-  GITHUB_REPO    - GitHub repository (default: rhel-lightspeed/linux-mcp-server)
-  GITLAB_PROJECT - GitLab project path (default: rhel-lightspeed/mcp/linux-mcp-server)
-  GITLAB_HOST    - GitLab hostname (default: gitlab.cee.redhat.com)
+  GITHUB_REPO          - GitHub repository (default: rhel-lightspeed/linux-mcp-server)
+  GITLAB_PROJECT       - GitLab project path (default: rhel-lightspeed/mcp/linux-mcp-server)
+  GITLAB_HOST          - GitLab hostname (default: gitlab.cee.redhat.com)
+  GITHUB_STATUS_TOKEN  - GitHub PAT for posting commit statuses (if unset, status posting is skipped)
 """
 
 import json
@@ -22,6 +23,7 @@ import os
 import subprocess
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 
@@ -52,6 +54,44 @@ def fetch_pr_info(github_repo, pr_number):
         sys.exit(f"ERROR: Could not connect to GitHub API: {e.reason}")
 
 
+def get_mr_url(gitlab_host, gitlab_project, branch_name):
+    """Look up the URL of the GitLab MR for the given branch."""
+    encoded_project = urllib.parse.quote(gitlab_project, safe="")
+    url = (
+        f"https://{gitlab_host}/api/v4/projects/{encoded_project}"
+        f"/merge_requests?source_branch={branch_name}&state=opened"
+    )
+    with urllib.request.urlopen(url) as response:
+        mrs = json.loads(response.read().decode())
+
+    if not mrs:
+        raise RuntimeError(f"No open MR found for branch {branch_name}")
+    return mrs[0]["web_url"]
+
+
+def post_github_status(github_repo, commit_sha, state, target_url, description, github_token):
+    """Post a commit status to GitHub."""
+    url = f"https://api.github.com/repos/{github_repo}/statuses/{commit_sha}"
+    payload = json.dumps({
+        "state": state,
+        "target_url": target_url,
+        "description": description,
+        "context": "gitlab / mirror",
+    }).encode()
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={
+            "Authorization": f"token {github_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/vnd.github+json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as response:
+        print(f"Posted GitHub status: {state}")
+
+
 def main():
     github_repo = os.environ.get("GITHUB_REPO", "rhel-lightspeed/linux-mcp-server")
     gitlab_project = os.environ.get("GITLAB_PROJECT", "rhel-lightspeed/mcp/linux-mcp-server")
@@ -59,6 +99,7 @@ def main():
     pr_number = os.environ.get("GITHUB_PR_NUMBER", "")
     commit_sha = os.environ.get("GITHUB_COMMIT_SHA", "")
     gitlab_token = os.environ.get("GITLAB_TOKEN", "")
+    github_status_token = os.environ.get("GITHUB_STATUS_TOKEN", "")
 
     if not pr_number or not commit_sha:
         sys.exit("ERROR: GITHUB_PR_NUMBER and GITHUB_COMMIT_SHA are required")
@@ -124,6 +165,20 @@ def main():
             cwd="repo",
         )
         print(f"Created MR for branch {branch_name}")
+
+    # Post success status back to GitHub
+    if github_status_token:
+        mr_url = get_mr_url(gitlab_host, gitlab_project, branch_name)
+        post_github_status(
+            github_repo,
+            commit_sha,
+            state="success",
+            target_url=mr_url,
+            description="Mirrored to internal GitLab",
+            github_token=github_status_token,
+        )
+    else:
+        print("GITHUB_STATUS_TOKEN not set, skipping GitHub status update")
 
 
 if __name__ == "__main__":

--- a/scripts/mirror_github_pr.py
+++ b/scripts/mirror_github_pr.py
@@ -23,8 +23,12 @@ import os
 import subprocess
 import sys
 import urllib.error
-import urllib.parse
 import urllib.request
+
+from pipeline_utils import get_mr_info
+from pipeline_utils import GitHubAPI
+from pipeline_utils import GitLabAPI
+from pipeline_utils import post_github_status
 
 
 def run_git(*args, cwd=None):
@@ -32,7 +36,7 @@ def run_git(*args, cwd=None):
     subprocess.run(["git", *args], check=True, cwd=cwd)
 
 
-def branch_exists(branch_name, cwd):
+def branch_exists(branch_name, *, cwd):
     """Check if a branch exists on the GitLab remote."""
     result = subprocess.run(
         ["git", "ls-remote", "--exit-code", "origin", f"refs/heads/{branch_name}"],
@@ -42,9 +46,9 @@ def branch_exists(branch_name, cwd):
     return result.returncode == 0
 
 
-def fetch_pr_info(github_repo, pr_number):
+def fetch_pr_info(pr_number, *, github: GitHubAPI):
     """Fetch PR metadata from the GitHub API."""
-    url = f"https://api.github.com/repos/{github_repo}/pulls/{pr_number}"
+    url = f"https://api.github.com/repos/{github.repo}/pulls/{pr_number}"
     try:
         with urllib.request.urlopen(url) as response:
             return json.loads(response.read().decode())
@@ -54,65 +58,24 @@ def fetch_pr_info(github_repo, pr_number):
         sys.exit(f"ERROR: Could not connect to GitHub API: {e.reason}")
 
 
-def get_mr_url(gitlab_host, gitlab_project, branch_name):
-    """Look up the URL of the GitLab MR for the given branch."""
-    encoded_project = urllib.parse.quote(gitlab_project, safe="")
-    url = (
-        f"https://{gitlab_host}/api/v4/projects/{encoded_project}"
-        f"/merge_requests?source_branch={branch_name}&state=opened"
-    )
-    with urllib.request.urlopen(url) as response:
-        mrs = json.loads(response.read().decode())
-
-    if not mrs:
-        raise RuntimeError(f"No open MR found for branch {branch_name}")
-    return mrs[0]["web_url"]
-
-
-def post_github_status(github_repo, commit_sha, state, target_url, description, github_token):
-    """Post a commit status to GitHub."""
-    url = f"https://api.github.com/repos/{github_repo}/statuses/{commit_sha}"
-    payload = json.dumps({
-        "state": state,
-        "target_url": target_url,
-        "description": description,
-        "context": "gitlab / mirror",
-    }).encode()
-    req = urllib.request.Request(
-        url,
-        data=payload,
-        headers={
-            "Authorization": f"token {github_token}",
-            "Content-Type": "application/json",
-            "Accept": "application/vnd.github+json",
-        },
-        method="POST",
-    )
-    with urllib.request.urlopen(req) as response:
-        print(f"Posted GitHub status: {state}")
-
-
 def main():
-    github_repo = os.environ.get("GITHUB_REPO", "rhel-lightspeed/linux-mcp-server")
-    gitlab_project = os.environ.get("GITLAB_PROJECT", "rhel-lightspeed/mcp/linux-mcp-server")
-    gitlab_host = os.environ.get("GITLAB_HOST", "gitlab.cee.redhat.com")
+    # optional: GITHUB_REPO / GITHUB_STATUS_TOKEN
+    github = GitHubAPI.from_environment()
+
+    # requires: GITLAB_TOKEN, optional: GITLAB_PROJECT / GITLAB_HOST
+    gitlab = GitLabAPI.from_environment()
+
     pr_number = os.environ.get("GITHUB_PR_NUMBER", "")
     commit_sha = os.environ.get("GITHUB_COMMIT_SHA", "")
-    gitlab_token = os.environ.get("GITLAB_TOKEN", "")
-    github_status_token = os.environ.get("GITHUB_STATUS_TOKEN", "")
-
     if not pr_number or not commit_sha:
         sys.exit("ERROR: GITHUB_PR_NUMBER and GITHUB_COMMIT_SHA are required")
 
-    if not gitlab_token:
-        sys.exit("ERROR: GITLAB_TOKEN is required")
-
     branch_name = f"github-pr-{pr_number}"
-    gitlab_remote = f"https://oauth2:{gitlab_token}@{gitlab_host}/{gitlab_project}.git"
+    gitlab_remote = f"https://oauth2:{gitlab.token}@{gitlab.host}/{gitlab.project}.git"
 
     # Fetch PR information from GitHub
     print(f"Fetching PR #{pr_number} from GitHub...")
-    pr_info = fetch_pr_info(github_repo, pr_number)
+    pr_info = fetch_pr_info(pr_number, github=github)
 
     pr_title = pr_info.get("title")
     pr_url = pr_info.get("html_url")
@@ -128,7 +91,7 @@ def main():
     run_git("clone", gitlab_remote, "repo")
 
     print(f"Fetching commit {commit_sha[:7]} from GitHub...")
-    run_git("remote", "add", "github", f"https://github.com/{github_repo}.git", cwd="repo")
+    run_git("remote", "add", "github", f"https://github.com/{github.repo}.git", cwd="repo")
     run_git("fetch", "github", commit_sha, cwd="repo")
     run_git("checkout", "-b", branch_name, commit_sha, cwd="repo")
 
@@ -167,15 +130,15 @@ def main():
         print(f"Created MR for branch {branch_name}")
 
     # Post success status back to GitHub
-    if github_status_token:
-        mr_url = get_mr_url(gitlab_host, gitlab_project, branch_name)
+    if github.token:
+        _, mr_url = get_mr_info(branch_name, gitlab=gitlab)
         post_github_status(
-            github_repo,
-            commit_sha,
+            commit_sha=commit_sha,
             state="success",
-            target_url=mr_url,
+            context="gitlab / mirror",
             description="Mirrored to internal GitLab",
-            github_token=github_status_token,
+            target_url=mr_url,
+            github=github,
         )
     else:
         print("GITHUB_STATUS_TOKEN not set, skipping GitHub status update")

--- a/scripts/pipeline_utils.py
+++ b/scripts/pipeline_utils.py
@@ -1,0 +1,79 @@
+"""Shared utilities for CI pipeline scripts that bridge GitLab and GitHub."""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from dataclasses import dataclass
+
+
+@dataclass
+class GitLabAPI:
+    project: str
+    host: str
+    token: str
+
+    @staticmethod
+    def from_environment():
+        project = os.environ.get("GITLAB_PROJECT", "rhel-lightspeed/mcp/linux-mcp-server")
+        host = os.environ.get("GITLAB_HOST", "gitlab.cee.redhat.com")
+        token = os.environ.get("GITLAB_TOKEN", "")
+        if not token:
+            sys.exit("ERROR: GITLAB_TOKEN is required")
+
+        return GitLabAPI(project=project, host=host, token=token)
+
+    def get(self, path):
+        """Make an GET request to the GitLab API"""
+        encoded_project = urllib.parse.quote(self.project, safe="")
+        url = f"https://{self.host}/api/v4/projects/{encoded_project}/{path}"
+        headers = {}
+        headers["PRIVATE-TOKEN"] = self.token
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req) as response:
+            res = json.loads(response.read().decode())
+            return res
+
+
+@dataclass
+class GitHubAPI:
+    repo: str
+    token: str
+
+    @staticmethod
+    def from_environment():
+        repo = os.environ.get("GITHUB_REPO", "rhel-lightspeed/linux-mcp-server")
+        token = os.environ.get("GITHUB_STATUS_TOKEN", "")
+
+        return GitHubAPI(repo, token)
+
+
+def get_mr_info(branch_name, gitlab: GitLabAPI):
+    """Look up the GitLab MR for a branch. Returns (iid, web_url)."""
+    mrs = gitlab.get(f"merge_requests?source_branch={branch_name}&state=opened")
+    if not mrs:
+        raise RuntimeError(f"No open MR found for branch {branch_name}")
+    return mrs[0]["iid"], mrs[0]["web_url"]
+
+
+def post_github_status(*, commit_sha, state, context, description, target_url=None, github: GitHubAPI):
+    """Post a commit status to GitHub."""
+    url = f"https://api.github.com/repos/{github.repo}/statuses/{commit_sha}"
+    payload = {"state": state, "context": context, "description": description}
+    if target_url:
+        payload["target_url"] = target_url
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={
+            "Authorization": f"token {github.token}",
+            "Content-Type": "application/json",
+            "Accept": "application/vnd.github+json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req):
+        print(f"Posted status: {context} = {state}")

--- a/scripts/report_konflux_status.py
+++ b/scripts/report_konflux_status.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Poll for Konflux build results and report them as GitHub commit statuses.
+
+After a PR is mirrored to GitLab, Konflux automatically builds the MR and
+posts progress comments on it. This script polls those comments and reports
+the outcome back to GitHub as a commit status ("konflux / build").
+
+Required environment variables:
+  GITHUB_PR_NUMBER    - The GitHub PR number
+  GITHUB_COMMIT_SHA   - The commit SHA to post statuses on
+  GITHUB_STATUS_TOKEN - GitHub PAT with repo:status scope
+  GITLAB_TOKEN        - GitLab access token with read_api scope
+  MIRROR_START_TIME   - ISO 8601 UTC timestamp recorded before the mirror push
+
+Optional environment variables:
+  GITHUB_REPO    - GitHub repository (default: rhel-lightspeed/linux-mcp-server)
+  GITLAB_PROJECT - GitLab project path (default: rhel-lightspeed/mcp/linux-mcp-server)
+  GITLAB_HOST    - GitLab hostname (default: gitlab.cee.redhat.com)
+"""
+
+import os
+import re
+import sys
+import time
+
+from pipeline_utils import get_mr_info
+from pipeline_utils import GitHubAPI
+from pipeline_utils import GitLabAPI
+from pipeline_utils import post_github_status
+
+
+KONFLUX_PREFIX = "**Konflux Production Internal/linux-mcp-server-pr**"
+RUN_NAME_PATTERN = re.compile(r"linux-mcp-server-pr-[a-z0-9]+")
+PIPELINE_URL_PATTERN = re.compile(
+    r"https://konflux-ui\.apps\.stone-prod-p02\.hjvn\.p1\.openshiftapps\.com"
+    r"/ns/[a-z0-9-]+/pipelinerun/linux-mcp-server-pr-[a-z0-9]+"
+)
+
+KONFLUX_START_INTERVAL = 30
+KONFLUX_START_TIMEOUT = 5 * 60
+KONFLUX_RESULT_INTERVAL = 5 * 60
+KONFLUX_RESULT_TIMEOUT = 2 * 60 * 60
+
+
+def get_mr_notes(mr_iid, *, gitlab_api: GitLabAPI):
+    """Fetch recent notes from a GitLab MR, newest first."""
+    return gitlab_api.get(f"merge_requests/{mr_iid}/notes?sort=desc&order_by=created_at&per_page=20")
+
+
+def normalize_timestamp(ts):
+    """Strip fractional seconds from a GitLab timestamp for comparison."""
+    return re.sub(r"\.\d+Z$", "Z", ts)
+
+
+def find_konflux_notes(notes, after_time):
+    """Filter MR notes to Konflux notes created after after_time."""
+    result = []
+    for note in notes:
+        if not note["body"].startswith(KONFLUX_PREFIX):
+            continue
+        if normalize_timestamp(note["created_at"]) <= after_time:
+            continue
+        result.append(note)
+    return result
+
+
+def classify_konflux_note(body):
+    """Classify a Konflux note as queued/starting/success/failure."""
+    if "has been queued" in body:
+        return "queued"
+    if "Starting Pipelinerun" in body:
+        return "starting"
+    if "has successfully validated your commit" in body:
+        return "success"
+    if "has failed" in body:
+        return "failure"
+    return None
+
+
+def extract_run_name(body):
+    """Extract the PipelineRun name from a Konflux note."""
+    match = RUN_NAME_PATTERN.search(body)
+    return match.group(0) if match else None
+
+
+def extract_pipeline_url(body):
+    """Extract the full Konflux PipelineRun URL from a note."""
+    match = PIPELINE_URL_PATTERN.search(body)
+    return match.group(0) if match else None
+
+
+def poll_for_konflux_start(*, mr_iid, after_time, gitlab: GitLabAPI):
+    """Poll MR notes until a Konflux build appears. Returns the run name."""
+    deadline = time.monotonic() + KONFLUX_START_TIMEOUT
+    while True:
+        notes = get_mr_notes(mr_iid, gitlab_api=gitlab)
+        for note in find_konflux_notes(notes, after_time):
+            run_name = extract_run_name(note["body"])
+            if run_name:
+                return run_name
+        if time.monotonic() >= deadline:
+            sys.exit(f"ERROR: Timed out waiting for Konflux build to start ({KONFLUX_START_TIMEOUT / 60:.2g} minutes)")
+        print(f"Waiting for Konflux to start... (polling every {KONFLUX_START_INTERVAL}s)")
+        time.sleep(KONFLUX_START_INTERVAL)
+
+
+def poll_for_konflux_result(*, mr_iid, after_time, run_name, gitlab: GitLabAPI):
+    """Poll MR notes until the Konflux build completes. Returns (state, url)."""
+    deadline = time.monotonic() + KONFLUX_RESULT_TIMEOUT
+    while True:
+        notes = get_mr_notes(mr_iid, gitlab_api=gitlab)
+        for note in find_konflux_notes(notes, after_time):
+            if run_name not in note["body"]:
+                continue
+            kind = classify_konflux_note(note["body"])
+            if kind in ("success", "failure"):
+                pipeline_url = extract_pipeline_url(note["body"])
+                return kind, pipeline_url
+        if time.monotonic() >= deadline:
+            sys.exit(
+                f"ERROR: Timed out waiting for Konflux build {run_name} "
+                f"to complete ({KONFLUX_RESULT_TIMEOUT / 3600:.2g} hours)"
+            )
+        print(f"Konflux build {run_name} in progress... (polling every {KONFLUX_RESULT_INTERVAL / 60:.2g}m)")
+        time.sleep(KONFLUX_RESULT_INTERVAL)
+
+
+def main():
+    # optional: GITHUB_REPO / GITHUB_STATUS_TOKEN
+    github = GitHubAPI.from_environment()
+
+    # requires: GITLAB_TOKEN, optional: GITLAB_PROJECT / GITLAB_HOST
+    gitlab = GitLabAPI.from_environment()
+
+    pr_number = os.environ.get("GITHUB_PR_NUMBER", "")
+    commit_sha = os.environ.get("GITHUB_COMMIT_SHA", "")
+    mirror_start_time = os.environ.get("MIRROR_START_TIME", "")
+
+    if not pr_number or not commit_sha:
+        sys.exit("ERROR: GITHUB_PR_NUMBER and GITHUB_COMMIT_SHA are required")
+    if not github.token:
+        sys.exit("ERROR: GITHUB_STATUS_TOKEN is required")
+    if not mirror_start_time:
+        sys.exit("ERROR: MIRROR_START_TIME is required")
+
+    branch_name = f"github-pr-{pr_number}"
+
+    # Look up the GitLab MR
+    print(f"Looking up MR for branch {branch_name}...")
+    mr_iid, mr_url = get_mr_info(branch_name, gitlab=gitlab)
+    print(f"Found MR !{mr_iid}: {mr_url}")
+
+    # Post initial pending status for Konflux
+    post_github_status(
+        commit_sha=commit_sha,
+        state="pending",
+        context="konflux / build",
+        description="Waiting for Konflux build to start",
+        target_url=mr_url,
+        github=github,
+    )
+
+    # Poll for Konflux build start
+    print("Polling for Konflux build to start...")
+    run_name = poll_for_konflux_start(mr_iid=mr_iid, after_time=mirror_start_time, gitlab=gitlab)
+    print(f"Konflux build started: {run_name}")
+
+    # Update status to show build is running
+    post_github_status(
+        commit_sha=commit_sha,
+        state="pending",
+        context="konflux / build",
+        description=f"Build in progress: {run_name}",
+        target_url=mr_url,
+        github=github,
+    )
+
+    # Poll for Konflux build result
+    print(f"Polling for Konflux build result ({run_name})...")
+    result_state, pipeline_url = poll_for_konflux_result(
+        mr_iid=mr_iid, after_time=mirror_start_time, run_name=run_name, gitlab=gitlab
+    )
+    print(f"Konflux build {result_state}: {pipeline_url}")
+
+    # Post final Konflux status
+    if result_state == "success":
+        description = "Konflux build succeeded"
+    else:
+        description = "Konflux build failed"
+
+    post_github_status(
+        commit_sha=commit_sha,
+        state=result_state,
+        context="konflux / build",
+        description=description,
+        target_url=pipeline_url or mr_url,
+        github=github,
+    )
+
+    if result_state == "failure":
+        print(f"ERROR: Konflux build failed: {pipeline_url}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The current system where we post comments to Git Hub issues with an URL to create a job to sync them to gitlab has various issues:

 * The comment posting is noisy ... it really doesn't need to end up in the email notification stream
 * There's no way to tell if there's an existing sync'ed PR without going to the Git Lab web UI and looking for it
 * It's hard to tell if the CI jobs that are the point of the sync completed successfully or not - again you have to poke arond in the GitLab web UI to find the sync'ed MR.

This pull request attempts to improve things by using the Git HUb "commit status" API.

 - Instead of posting comments saying how to sync, that's done as a "Pending" status where the details link takes you to the same "pipeline/new" form.
 - When the sync happens, that status is shown as complete
 - After the sync happens, we poll to see the Konflux job kick off and complete, and update a separate status for that

We might eventually also want to post the Konflux results as a comment in addition to the status. Also, this doesn't try to figure out how to post back the results of the gatekeeper eval job - I'm not sure if that actually makes sense as a status at all, or just as a comment.

One annoying wart is that the avatar of the status is the user who created the PAT, so if I create the token, then my face shows up:

<img width="1147" height="187" alt="image" src="https://github.com/user-attachments/assets/6fd90379-77b1-457f-bb83-f48d8dc48c0d" />

We might want to create a "robot" GitHub account with shared access to get around this. ([Some guidance on handling auth for that](https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-two-factor-authentication-for-your-organization/managing-bots-and-service-accounts-with-two-factor-authentication)) 