### PR TITLE
chore(deps): enforce 7-day minimum package age for npm and uv

### DIFF
--- a/mcp-app/.npmrc
+++ b/mcp-app/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,3 +210,6 @@ order-by-type = false
 artifacts = [
     "mcp-app/dist",
 ]
+
+[tool.uv]
+exclude-newer = "7 days"

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiofile"
 version = "3.9.0"


### PR DESCRIPTION
Mitigate supply chain risk by only installing packages that have been published for at least 7 days. Configured via npm's min-release-age and uv's exclude-newer settings.

While lockfiles generally protect us from supply chain attacks, certain development scenarios still expose us to risk. For instance, when adding a new package or manually modifying a version to test features, the lockfile cannot guard against potential threats.