### PR TITLE
chore: group npm dependency updates into a single weekly PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,11 @@
     {
       "matchDepNames": ["python"],
       "enabled": false
+    },
+    {
+      "matchManagers": ["npm"],
+      "groupName": "mcp-app npm dependencies",
+      "schedule": ["before 9am on monday"]
     }
   ]
 }


### PR DESCRIPTION
Reduces Renovate noise by batching all non-security npm updates into one PR per week (Monday mornings). Vulnerability alerts are unaffected and continue to arrive immediately.

This is untested ... figuring out how to set up renovate seemed to much work. So :crossed_fingers: 