### PR TITLE
[RSPEED-3010]feat: add ExecutionContext for authorization

### DIFF
--- a/src/linux_mcp_server/connection/ssh.py
+++ b/src/linux_mcp_server/connection/ssh.py
@@ -24,6 +24,7 @@ from linux_mcp_server.audit import log_ssh_command
 from linux_mcp_server.audit import log_ssh_connect
 from linux_mcp_server.audit import Status
 from linux_mcp_server.config import CONFIG
+from linux_mcp_server.execution_context import get_execution_context
 from linux_mcp_server.utils.types import Host
 
 
@@ -376,11 +377,24 @@ async def execute_command(
         ...     username="admin"
         ... )
     """
+    # Get execution context, fail-closed if not set
+    context = get_execution_context()
+    if context is None:
+        raise RuntimeError("No execution context set cannot execute commands")
+
     cmd_str = " ".join(command)
 
     if host:
+        # Remote execution, check permissions
+        if not context.allow_ssh_default and context.ssh_key_path is None:
+            raise RuntimeError("Remote execution not allowed")
+
         logger.debug(f"Routing to remote execution: {host} | command={cmd_str}")
         return await _connection_manager.execute_remote(command, host, encoding=encoding)
+
+    # Local execution,check permissions
+    if not context.allow_local:
+        raise RuntimeError("Local execution not allowed")
 
     logger.debug(f"LOCAL_EXEC: {cmd_str}")
     return await _execute_local(command, encoding=encoding)

--- a/src/linux_mcp_server/connection/ssh.py
+++ b/src/linux_mcp_server/connection/ssh.py
@@ -111,7 +111,18 @@ class SSHConnectionManager:
         Raises:
             ConnectionError: If connection fails
         """
-        key = f"{host}"
+        # Get SSH credentials from ExecutionContext if available
+        context = get_execution_context()
+        if context is not None:
+            ssh_key = str(context.ssh_key_path) if context.ssh_key_path else self._ssh_key
+            username = context.ssh_key_user or CONFIG.user
+        else:
+            # No context set - use defaults
+            ssh_key = self._ssh_key
+            username = CONFIG.user
+
+        # Build pool key including SSH key and username to avoid connection reuse conflicts
+        key = f"{host}:{ssh_key or 'default'}:{username or 'default'}"
 
         # Return existing connection if available
         if key in self._connections:
@@ -125,7 +136,7 @@ class SSHConnectionManager:
                     username=conn.get_extra_info("username"),
                     status=Status.success,
                     reused=True,
-                    key_path=self._ssh_key,
+                    key_path=ssh_key,
                 )
                 return conn
             else:
@@ -135,7 +146,7 @@ class SSHConnectionManager:
 
         # Create new connection
         # DEBUG level: Log connection attempt before it completes
-        logger.debug(f"{Event.SSH_CONNECTING}: {key} | key={self._ssh_key or 'none'}")
+        logger.debug(f"{Event.SSH_CONNECTING}: {key} | key={ssh_key or 'none'}")
 
         try:
             # Determine host key verification settings
@@ -151,11 +162,13 @@ class SSHConnectionManager:
                 "passphrase": CONFIG.key_passphrase.get_secret_value() or None,
             }
 
-            if self._ssh_key:
-                connect_kwargs["client_keys"] = [self._ssh_key]
+            # Use custom SSH key if provided, otherwise use default
+            if ssh_key:
+                connect_kwargs["client_keys"] = [ssh_key]
 
-            if CONFIG.user:
-                connect_kwargs["username"] = CONFIG.user
+            # Use custom username if provided, otherwise use CONFIG.user
+            if username:
+                connect_kwargs["username"] = username
 
             conn = await asyncssh.connect(**connect_kwargs)
             self._connections[key] = conn
@@ -166,7 +179,7 @@ class SSHConnectionManager:
                 username=conn.get_extra_info("username"),
                 status=Status.success,
                 reused=False,
-                key_path=self._ssh_key,
+                key_path=ssh_key,
             )
 
             # DEBUG level: Log pool state

--- a/src/linux_mcp_server/execution_context.py
+++ b/src/linux_mcp_server/execution_context.py
@@ -1,0 +1,31 @@
+from contextlib import contextmanager
+from contextvars import ContextVar
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+class ExecutionContext(BaseModel):
+    allow_local: bool = False
+    allow_ssh_default: bool = False
+    ssh_key_path: Path | None = None
+    ssh_key_user: str | None = None
+
+
+# Global ContextVar for storing the current execution context if no context is set execution should fail
+execution_context_var: ContextVar[ExecutionContext | None] = ContextVar("execution_context", default=None)
+
+
+@contextmanager
+def use_execution_context(context: ExecutionContext):
+
+    token = execution_context_var.set(context)
+    try:
+        yield context
+    finally:
+        execution_context_var.reset(token)
+
+
+# Get the current execution context or None if not set
+def get_execution_context() -> ExecutionContext | None:
+    return execution_context_var.get()

--- a/src/linux_mcp_server/server.py
+++ b/src/linux_mcp_server/server.py
@@ -28,6 +28,8 @@ from linux_mcp_server.auth_policy import PolicyAction
 from linux_mcp_server.config import CONFIG
 from linux_mcp_server.config import Toolset
 from linux_mcp_server.config import Transport
+from linux_mcp_server.execution_context import ExecutionContext
+from linux_mcp_server.execution_context import use_execution_context
 from linux_mcp_server.mcp_app import hide_app_tools_for_client
 from linux_mcp_server.mcp_app import MCP_APP_MIME_TYPE
 from linux_mcp_server.mcp_app import RUN_SCRIPT_APP_URI
@@ -282,7 +284,9 @@ class AuthorizationMiddleware(Middleware):
 
         # For stdio without policy configured, allow everything
         if CONFIG.transport == Transport.stdio and CONFIG.policy_path is None:
-            return await call_next(context)
+            exec_context = ExecutionContext(allow_local=True, allow_ssh_default=True)
+            with use_execution_context(exec_context):
+                return await call_next(context)
 
         # For http transports log auth at INFO for audit trail info
         # For stdio use DEBUG to avoid noise
@@ -319,13 +323,26 @@ class AuthorizationMiddleware(Middleware):
         # Log the authorized action
         log_level(f"Authorized: tool={tool.name}, host={target_host or 'local'}, action={action.value}, user={email}")
 
-        # For SSH_KEY action, validate ssh_key_config (should be prevented by policy validation)
-        if action == PolicyAction.SSH_KEY:
-            if not ssh_key_config:
-                raise RuntimeError("Policy validation error: SSH_KEY action requires ssh_key configuration.")
-            logger.debug(f"SSH key override: path={ssh_key_config.path}, user={ssh_key_config.user}")
+        # Build ExecutionContext based on policy action
+        match action:
+            case PolicyAction.LOCAL:
+                exec_context = ExecutionContext(allow_local=True)
+            case PolicyAction.SSH_DEFAULT:
+                exec_context = ExecutionContext(allow_ssh_default=True)
+            case PolicyAction.SSH_KEY:
+                if not ssh_key_config:
+                    raise RuntimeError("Policy validation error: SSH_KEY action requires ssh_key configuration.")
+                logger.debug(f"SSH key override: path={ssh_key_config.path}, user={ssh_key_config.user}")
+                exec_context = ExecutionContext(
+                    ssh_key_path=Path(ssh_key_config.path),
+                    ssh_key_user=ssh_key_config.user,
+                )
+            case _:  # pragma: no cover
+                raise RuntimeError(f"Unexpected policy action: {action}")
 
-        return await call_next(context)
+        # Execute with the appropriate ExecutionContext
+        with use_execution_context(exec_context):
+            return await call_next(context)
 
 
 class DynamicDiscoveryMiddleware(Middleware):

--- a/tests/connection/ssh/test_connection_manager.py
+++ b/tests/connection/ssh/test_connection_manager.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+
 import asyncssh
 import pytest
 
 from linux_mcp_server.connection.ssh import SSHConnectionManager
+from linux_mcp_server.execution_context import ExecutionContext
+from linux_mcp_server.execution_context import use_execution_context
 
 
 @pytest.fixture
@@ -155,3 +159,36 @@ async def test_close_connections(mocker, mock_asyncssh_connect):
     assert mock_conn1.close.call_count == 1
     assert mock_conn2.close.call_count == 1
     assert len(manager._connections) == 0
+
+
+async def test_get_connection_uses_custom_ssh_key_from_context(mocker, mock_asyncssh_connect):
+    """Test get_connection reads ssh_key_path from ExecutionContext."""
+    mocker.patch("linux_mcp_server.connection.ssh.CONFIG.user", "defaultuser")
+
+    manager = SSHConnectionManager()
+    manager._connections.clear()
+    manager._ssh_key = "/default/.ssh/id_rsa"
+
+    context = ExecutionContext(ssh_key_path=Path("/custom/.ssh/custom_key"))
+
+    with use_execution_context(context):
+        await manager.get_connection("testhost")
+
+    call_kwargs = mock_asyncssh_connect.call_args.kwargs
+    assert call_kwargs.get("client_keys") == ["/custom/.ssh/custom_key"]
+
+
+async def test_get_connection_uses_custom_username_from_context(mocker, mock_asyncssh_connect):
+    """Test get_connection reads ssh_key_user from ExecutionContext."""
+    mocker.patch("linux_mcp_server.connection.ssh.CONFIG.user", "defaultuser")
+
+    manager = SSHConnectionManager()
+    manager._connections.clear()
+
+    context = ExecutionContext(ssh_key_user="customuser")
+
+    with use_execution_context(context):
+        await manager.get_connection("testhost")
+
+    call_kwargs = mock_asyncssh_connect.call_args.kwargs
+    assert call_kwargs.get("username") == "customuser"

--- a/tests/connection/ssh/test_execute_command.py
+++ b/tests/connection/ssh/test_execute_command.py
@@ -1,7 +1,20 @@
+from pathlib import Path
+
 import pytest
 
 from linux_mcp_server.connection.ssh import execute_command
 from linux_mcp_server.connection.ssh import SSHConnectionManager
+from linux_mcp_server.execution_context import ExecutionContext
+from linux_mcp_server.execution_context import use_execution_context
+
+
+@pytest.fixture
+def mock_connection_manager(mocker):
+    """Fixture to mock the SSH connection manager."""
+    mock_manager = mocker.Mock(spec=SSHConnectionManager)
+    mock_manager.execute_remote = mocker.AsyncMock(return_value=(0, "output", ""))
+    mocker.patch("linux_mcp_server.connection.ssh._connection_manager", mock_manager)
+    return mock_manager
 
 
 @pytest.mark.parametrize(
@@ -16,25 +29,99 @@ from linux_mcp_server.connection.ssh import SSHConnectionManager
 )
 async def test_execute_command_local(command, kwargs, expected_rc, expected_out, expected_err):
     """Test local command execution success."""
-    returncode, stdout, stderr = await execute_command(command, **kwargs)
+    context = ExecutionContext(allow_local=True)
+
+    with use_execution_context(context):
+        returncode, stdout, stderr = await execute_command(command, **kwargs)
 
     assert returncode == expected_rc
     assert expected_out in stdout
     assert expected_err in stderr
 
 
-async def test_execute_command_remote(mocker):
+async def test_execute_command_remote(mock_connection_manager):
     """Test that remote execution routes through SSH."""
-    mock_manager = mocker.Mock(SSHConnectionManager)
-    mock_manager.execute_remote = mocker.AsyncMock(return_value=(0, "output", ""))
-    mocker.patch("linux_mcp_server.connection.ssh._connection_manager", mock_manager)
+    context = ExecutionContext(allow_ssh_default=True)
 
-    returncode, stdout, stderr = await execute_command(
-        ["ls", "-la"],
-        host="remote.example.com",
-        username="testuser",
-    )
+    with use_execution_context(context):
+        returncode, stdout, stderr = await execute_command(
+            ["ls", "-la"],
+            host="remote.example.com",
+            username="testuser",
+        )
 
     assert returncode == 0
     assert stdout == "output"
-    assert mock_manager.execute_remote.call_count == 1
+    assert mock_connection_manager.execute_remote.call_count == 1
+
+
+async def test_execute_command_fails_without_context():
+    """Test execute_command fails when no ExecutionContext is set."""
+    with pytest.raises(RuntimeError, match="No execution context set"):
+        await execute_command(["echo", "test"])
+
+
+async def test_local_execution_allowed():
+    """Test local execution succeeds when allow_local=True."""
+    context = ExecutionContext(allow_local=True)
+
+    with use_execution_context(context):
+        returncode, stdout, stderr = await execute_command(["echo", "test"])
+
+    assert returncode == 0
+    assert isinstance(stdout, str)
+    assert "test" in stdout
+
+
+async def test_local_execution_denied():
+    """Test local execution fails when allow_local=False."""
+    context = ExecutionContext(allow_local=False)
+
+    with use_execution_context(context):
+        with pytest.raises(RuntimeError, match="Local execution not allowed"):
+            await execute_command(["echo", "test"])
+
+
+async def test_remote_execution_with_ssh_default_allowed(mock_connection_manager):
+    """Test remote execution succeeds when allow_ssh_default=True."""
+    context = ExecutionContext(allow_ssh_default=True)
+
+    with use_execution_context(context):
+        returncode, stdout, stderr = await execute_command(
+            ["ls", "-la"],
+            host="remote.example.com",
+        )
+
+    assert returncode == 0
+    assert stdout == "output"
+    assert mock_connection_manager.execute_remote.call_count == 1
+
+
+async def test_remote_execution_denied_no_permissions(mock_connection_manager):
+    """Test remote execution fails when no SSH permissions are set."""
+    context = ExecutionContext(allow_ssh_default=False, ssh_key_path=None)
+
+    with use_execution_context(context):
+        with pytest.raises(RuntimeError, match="Remote execution not allowed"):
+            await execute_command(["ls", "-la"], host="remote.example.com")
+
+    assert mock_connection_manager.execute_remote.call_count == 0
+
+
+async def test_remote_execution_with_ssh_key(mock_connection_manager):
+    """Test remote execution succeeds with ssh_key_path set."""
+    ssh_path = Path("/home/user/.ssh/id_rsa")
+    context = ExecutionContext(
+        allow_ssh_default=False,
+        ssh_key_path=ssh_path,
+        ssh_key_user="ubuntu",
+    )
+
+    with use_execution_context(context):
+        returncode, stdout, stderr = await execute_command(
+            ["ls", "-la"],
+            host="remote.example.com",
+        )
+
+    assert returncode == 0
+    assert mock_connection_manager.execute_remote.call_count == 1

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -334,3 +334,112 @@ class TestAuthorizationMiddleware:
 
         with pytest.raises(ToolError, match=r"Policy validation error: SSH_KEY action requires ssh_key configuration."):
             await client.call_tool("get_memory_information", {"host": "server1.example.com"})
+
+
+class CaptureContext:
+    def __init__(self):
+        self._context = None
+
+    async def _execute_with_fallback(self, *_args, **_kwargs):
+        from linux_mcp_server.execution_context import get_execution_context
+
+        self._context = get_execution_context()
+        return (0, FREE_OUTPUT, "")
+
+    def get_context(self):
+        return self._context
+
+
+class TestExecutionContextMiddlewareIntegration:
+    @pytest.fixture
+    def capture_context(self, mocker):
+        capture = CaptureContext()
+        mocker.patch("linux_mcp_server.commands.execute_with_fallback", side_effect=capture._execute_with_fallback)
+        return capture
+
+    async def test_stdio_without_policy_allows_all(self, mcp_client, mocker, capture_context):
+        """Verify stdio without policy sets ExecutionContext with allow_local=True, allow_ssh_default=True."""
+        mocker.patch("linux_mcp_server.server.CONFIG.transport", "stdio")
+        mocker.patch("linux_mcp_server.server.CONFIG.policy_path", None)
+
+        await mcp_client.call_tool("get_memory_information")
+
+        captured_context = capture_context.get_context()
+        assert captured_context is not None
+        assert captured_context.allow_local is True
+        assert captured_context.allow_ssh_default is True
+
+    async def test_local_policy_sets_local_context(self, mcp_client, mocker, capture_context):
+        """Verify LOCAL policy action sets ExecutionContext with allow_local=True only."""
+        mocker.patch("linux_mcp_server.server.CONFIG.transport", "streamable-http")
+        mocker.patch("linux_mcp_server.server.CONFIG.policy_path", "/etc/policy.json")
+        mocker.patch(
+            "linux_mcp_server.auth_policy.get_policy",
+            return_value=AuthPolicy(
+                rules=[PolicyRule(host="localhost", tools=["@fixed"], all_users=True, action=PolicyAction.LOCAL)]
+            ),
+        )
+
+        await mcp_client.call_tool("get_memory_information")
+
+        captured_context = capture_context.get_context()
+        assert captured_context is not None
+        assert captured_context.allow_local is True
+        assert captured_context.allow_ssh_default is False
+        assert captured_context.ssh_key_path is None
+
+    async def test_ssh_default_policy_sets_ssh_context(self, mcp_client, mocker, capture_context):
+        """Verify SSH_DEFAULT policy action sets ExecutionContext with allow_ssh_default=True."""
+        mocker.patch("linux_mcp_server.server.CONFIG.transport", "streamable-http")
+        mocker.patch("linux_mcp_server.server.CONFIG.policy_path", "/etc/policy.json")
+        mocker.patch(
+            "linux_mcp_server.auth_policy.get_policy",
+            return_value=AuthPolicy(
+                rules=[
+                    PolicyRule(
+                        host="server1.example.com",
+                        tools=["@fixed"],
+                        all_users=True,
+                        action=PolicyAction.SSH_DEFAULT,
+                    )
+                ]
+            ),
+        )
+
+        await mcp_client.call_tool("get_memory_information", {"host": "server1.example.com"})
+
+        captured_context = capture_context.get_context()
+        assert captured_context is not None
+        assert captured_context.allow_local is False
+        assert captured_context.allow_ssh_default is True
+        assert captured_context.ssh_key_path is None
+
+    async def test_ssh_key_policy_sets_key_context(self, mcp_client, mocker, capture_context):
+        """Verify SSH_KEY policy action sets ExecutionContext with ssh_key_path and ssh_key_user."""
+        from pathlib import Path
+
+        mocker.patch("linux_mcp_server.server.CONFIG.transport", "streamable-http")
+        mocker.patch("linux_mcp_server.server.CONFIG.policy_path", "/etc/policy.json")
+        mocker.patch(
+            "linux_mcp_server.auth_policy.get_policy",
+            return_value=AuthPolicy(
+                rules=[
+                    PolicyRule(
+                        host="server1.example.com",
+                        tools=["@fixed"],
+                        all_users=True,
+                        action=PolicyAction.SSH_KEY,
+                        ssh_key=SSHKeyConfig(path="/keys/server1.key", user="serviceaccount"),
+                    )
+                ]
+            ),
+        )
+
+        await mcp_client.call_tool("get_memory_information", {"host": "server1.example.com"})
+
+        captured_context = capture_context.get_context()
+        assert captured_context is not None
+        assert captured_context.allow_local is False
+        assert captured_context.allow_ssh_default is False
+        assert captured_context.ssh_key_path == Path("/keys/server1.key")
+        assert captured_context.ssh_key_user == "serviceaccount"


### PR DESCRIPTION
added ExecutionContext system to authorization at the execution with fail-closed

- added ExecutionContext model with permission fields
- added ContextVar for context propagation
- modified execute_command() to require ExecutionContext
- modified AuthorizationMiddleware to set ExecutionContext
- added tests for ContextVar and execute_command integration
- added TestExecutionContextMiddlewareIntegration tests