### PR TITLE
Handle internal CA certificates for private GitLab servers

### DIFF
--- a/.gitlab/ci/eval-gatekeeper.yml
+++ b/.gitlab/ci/eval-gatekeeper.yml
@@ -29,6 +29,7 @@ download-secure-files:
   image: registry.gitlab.com/gitlab-org/cli:latest
   script:
     - mkdir -p securefiles
+    - '[ -z "$CI_SERVER_TLS_CA_FILE" ] || glab config set ca_cert "$CI_SERVER_TLS_CA_FILE" --host "$CI_SERVER_FQDN"'
     - glab auth login --job-token $CI_JOB_TOKEN --hostname $CI_SERVER_FQDN --api-protocol $CI_SERVER_PROTOCOL
     - glab -R $CI_PROJECT_PATH securefile download --all --output-dir="./securefiles"
     - cd securefiles && ls

--- a/scripts/mirror_github_pr.py
+++ b/scripts/mirror_github_pr.py
@@ -12,10 +12,11 @@ Required environment variables:
   GITLAB_TOKEN      - GitLab access token with 'write_repository' scope
 
 Optional environment variables:
-  GITHUB_REPO          - GitHub repository (default: rhel-lightspeed/linux-mcp-server)
-  GITLAB_PROJECT       - GitLab project path (default: rhel-lightspeed/mcp/linux-mcp-server)
-  GITLAB_HOST          - GitLab hostname (default: gitlab.cee.redhat.com)
-  GITHUB_STATUS_TOKEN  - GitHub PAT for posting commit statuses (if unset, status posting is skipped)
+  GITHUB_REPO           - GitHub repository (default: rhel-lightspeed/linux-mcp-server)
+  CI_PROJECT_PATH       - GitLab project path (default: rhel-lightspeed/mcp/linux-mcp-server)
+  CI_SERVER_FQDN        - GitLab hostname (default: gitlab.cee.redhat.com)
+  CI_SERVER_TLS_CA_FILE - Path to CA certificate for the GitLab server
+  GITHUB_STATUS_TOKEN   - GitHub PAT for posting commit statuses (if unset, status posting is skipped)
 """
 
 import json
@@ -62,7 +63,7 @@ def main():
     # optional: GITHUB_REPO / GITHUB_STATUS_TOKEN
     github = GitHubAPI.from_environment()
 
-    # requires: GITLAB_TOKEN, optional: GITLAB_PROJECT / GITLAB_HOST
+    # requires: GITLAB_TOKEN, optional: CI_PROJECT_PATH / CI_SERVER_FQDN
     gitlab = GitLabAPI.from_environment()
 
     pr_number = os.environ.get("GITHUB_PR_NUMBER", "")

--- a/scripts/pipeline_utils.py
+++ b/scripts/pipeline_utils.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import ssl
 import sys
 import urllib.error
 import urllib.parse
@@ -10,21 +11,31 @@ import urllib.request
 from dataclasses import dataclass
 
 
+def _gitlab_ssl_context():
+    """Build an SSL context that trusts CI_SERVER_TLS_CA_FILE when set."""
+    ca_file = os.environ.get("CI_SERVER_TLS_CA_FILE")
+    if ca_file:
+        ctx = ssl.create_default_context(cafile=ca_file)
+        return ctx
+    return None
+
+
 @dataclass
 class GitLabAPI:
     project: str
     host: str
     token: str
+    ssl_context: ssl.SSLContext | None = None
 
     @staticmethod
     def from_environment():
-        project = os.environ.get("GITLAB_PROJECT", "rhel-lightspeed/mcp/linux-mcp-server")
-        host = os.environ.get("GITLAB_HOST", "gitlab.cee.redhat.com")
+        project = os.environ.get("CI_PROJECT_PATH", "rhel-lightspeed/mcp/linux-mcp-server")
+        host = os.environ.get("CI_SERVER_FQDN", "gitlab.cee.redhat.com")
         token = os.environ.get("GITLAB_TOKEN", "")
         if not token:
             sys.exit("ERROR: GITLAB_TOKEN is required")
 
-        return GitLabAPI(project=project, host=host, token=token)
+        return GitLabAPI(project=project, host=host, token=token, ssl_context=_gitlab_ssl_context())
 
     def get(self, path):
         """Make an GET request to the GitLab API"""
@@ -33,7 +44,7 @@ class GitLabAPI:
         headers = {}
         headers["PRIVATE-TOKEN"] = self.token
         req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req) as response:
+        with urllib.request.urlopen(req, context=self.ssl_context) as response:
             res = json.loads(response.read().decode())
             return res
 

--- a/scripts/report_konflux_status.py
+++ b/scripts/report_konflux_status.py
@@ -14,9 +14,10 @@ Required environment variables:
   MIRROR_START_TIME   - ISO 8601 UTC timestamp recorded before the mirror push
 
 Optional environment variables:
-  GITHUB_REPO    - GitHub repository (default: rhel-lightspeed/linux-mcp-server)
-  GITLAB_PROJECT - GitLab project path (default: rhel-lightspeed/mcp/linux-mcp-server)
-  GITLAB_HOST    - GitLab hostname (default: gitlab.cee.redhat.com)
+  GITHUB_REPO           - GitHub repository (default: rhel-lightspeed/linux-mcp-server)
+  CI_PROJECT_PATH       - GitLab project path (default: rhel-lightspeed/mcp/linux-mcp-server)
+  CI_SERVER_FQDN        - GitLab hostname (default: gitlab.cee.redhat.com)
+  CI_SERVER_TLS_CA_FILE - Path to CA certificate for the GitLab server
 """
 
 import os
@@ -130,7 +131,7 @@ def main():
     # optional: GITHUB_REPO / GITHUB_STATUS_TOKEN
     github = GitHubAPI.from_environment()
 
-    # requires: GITLAB_TOKEN, optional: GITLAB_PROJECT / GITLAB_HOST
+    # requires: GITLAB_TOKEN, optional: CI_PROJECT_PATH / CI_SERVER_FQDN
     gitlab = GitLabAPI.from_environment()
 
     pr_number = os.environ.get("GITHUB_PR_NUMBER", "")


### PR DESCRIPTION
We have two related errors in our gitlab pipelines:
 * Since #475 the mirror job has been failing because it doesn't *just* use `gitlab.cee.redhat.com` through git, it also accesses it through the HTTP API, and while gitlab auto-configures git to trust the server's ssl cert (signed by Red Hat's internal cert), it doesn't do the same with the web API.
 * Since #450, the gatekeeper eval pipeline is failing because glab doesn't trust `gitlab.cee.redhat.com`

I think this PR should fix both. (Alternate fix would be to extend the `SSL_CERT_FILE` handling in `eval-gatekeeper.yml` to cover `glab` and `mirror.yml`, but this way feels cleaner, or at least more gitlab-ci-native.)