### PR TITLE
Correctly serialize null values

### DIFF
--- a/src/linux_mcp_server/models.py
+++ b/src/linux_mcp_server/models.py
@@ -196,5 +196,7 @@ class LogEntries(BaseModel):
     lines_count: int = Field(default_factory=field_length("entries"))
 
     @field_serializer("unit", "path")
-    def serialize_empty_as_null(self, value: str | Path | None) -> str | Path | None:
-        return value or None
+    def serialize_empty_as_null(self, value: str | Path | None) -> str | None:
+        if value:
+            return str(value)
+        return None

--- a/src/linux_mcp_server/models.py
+++ b/src/linux_mcp_server/models.py
@@ -197,6 +197,4 @@ class LogEntries(BaseModel):
 
     @field_serializer("unit", "path")
     def serialize_empty_as_null(self, value: str | Path | None) -> str | None:
-        if value:
-            return str(value)
-        return None
+        return str(value) if value else None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,11 @@
+from linux_mcp_server.models import LogEntries
+
+
+def test_log_entries_null_value_serialization():
+    """Assert that null values are properly serialized."""
+
+    log_entry = LogEntries(entries=["log"])
+    model = log_entry.model_dump()
+
+    assert model["unit"] is None
+    assert model["path"] is None

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -31,3 +31,17 @@ class TestToolSchemaExamples:
         assert param_name in props, f"Parameter '{param_name}' not found in {tool_name}"
         assert "examples" in props[param_name], f"Parameter '{param_name}' in {tool_name} missing examples"
         assert len(props[param_name]["examples"]) > 0, f"Parameter '{param_name}' in {tool_name} has empty examples"
+
+
+def test_log_entries_serialization_schema_no_path_format() -> None:
+    """Verify that LogEntries serialization schema does not contain 'format': 'path' for unit or path."""
+    from linux_mcp_server.models import LogEntries
+
+    schema = LogEntries.model_json_schema(mode="serialization")
+    for field_name in ("unit", "path"):
+        field_schema = schema.get("properties", {}).get(field_name, {})
+        # Verify it is not a direct 'format': 'path'
+        assert field_schema.get("format") != "path", f"Field '{field_name}' has format: 'path'"
+        # Verify it is not inside anyOf
+        for subschema in field_schema.get("anyOf", []):
+            assert subschema.get("format") != "path", f"Field '{field_name}' has subschema with format: 'path'"

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -31,17 +31,3 @@ class TestToolSchemaExamples:
         assert param_name in props, f"Parameter '{param_name}' not found in {tool_name}"
         assert "examples" in props[param_name], f"Parameter '{param_name}' in {tool_name} missing examples"
         assert len(props[param_name]["examples"]) > 0, f"Parameter '{param_name}' in {tool_name} has empty examples"
-
-
-def test_log_entries_serialization_schema_no_path_format() -> None:
-    """Verify that LogEntries serialization schema does not contain 'format': 'path' for unit or path."""
-    from linux_mcp_server.models import LogEntries
-
-    schema = LogEntries.model_json_schema(mode="serialization")
-    for field_name in ("unit", "path"):
-        field_schema = schema.get("properties", {}).get(field_name, {})
-        # Verify it is not a direct 'format': 'path'
-        assert field_schema.get("format") != "path", f"Field '{field_name}' has format: 'path'"
-        # Verify it is not inside anyOf
-        for subschema in field_schema.get("anyOf", []):
-            assert subschema.get("format") != "path", f"Field '{field_name}' has subschema with format: 'path'"


### PR DESCRIPTION
## Summary
Resolves issue #456. Updates serialize_empty_as_null return type annotation to str | None and converts Path to str to avoid generating non-standard format: path in LogEntries schema.

This removes unknown format 'path' warnings on MCP clients like OpenCode.