### PR TITLE
chore(renovate): use shared org config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,20 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "labels": ["dependencies"],
-  "minimumReleaseAge": "7 days",
-  "vulnerabilityAlerts": {
-    "labels": ["security"],
-    "minimumReleaseAge": "0 days"
-  },
+  "extends": ["github>rhel-lightspeed/renovate-config"],
   "packageRules": [
     {
       "matchManagers": ["pep621", "pip_requirements", "pip-compile", "poetry", "pipenv"],
       "rangeStrategy": "in-range-only"
-    },
-    {
-      "matchDepNames": ["python"],
-      "enabled": false
     },
     {
       "matchManagers": ["npm"],


### PR DESCRIPTION
## Summary

Switch from inline Renovate config to the shared `rhel-lightspeed/renovate-config` preset. Removes duplicated settings (labels, release age, vulnerability alerts, Python version pin) that are now org-wide defaults.

## Changes

- `extends` now points to `github>rhel-lightspeed/renovate-config` instead of `config:recommended`
- Removed settings covered by the shared preset: `labels`, `minimumReleaseAge`, `vulnerabilityAlerts`, Python version disable rule
- Kept repo-specific rules: Python `in-range-only` range strategy, npm Monday grouping

## Notes

The shared preset uses `config:best-practices` (superset of `config:recommended`) and groups all non-major updates into a single PR. Both are behavioral changes but consistent with org-wide intent.