### PR TITLE
Improve documentation for running in a container

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -43,7 +43,7 @@ Edit `~/.claude.json`:
     }
     ```
 
-=== "Container (stdio transport)"
+=== "Container (Podman)"
 
     ```json
     {
@@ -58,6 +58,33 @@ Edit `~/.claude.json`:
             "-v", "/home/YOUR_USER/.ssh/id_ed25519:/var/lib/mcp/.ssh/id_ed25519:ro,Z",
             "-v", "/home/YOUR_USER/.ssh/config:/var/lib/mcp/.ssh/config:ro,Z",
             "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw,Z",
+            "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
+          ],
+          "env": {
+            "LINUX_MCP_KEY_PASSPHRASE": "<secret>",
+            "LINUX_MCP_USER": "YOUR_USER"
+          }
+        }
+      }
+    }
+    ```
+
+    !!! warning "Replace Paths"
+        Replace `YOUR_USER` with your actual username.
+
+=== "Container (Docker)"
+
+    ```json
+    {
+      "mcpServers": {
+        "linux-mcp-server": {
+          "command": "docker",
+          "args": [
+            "run", "--rm", "--interactive",
+            "-e", "LINUX_MCP_KEY_PASSPHRASE",
+            "-e", "LINUX_MCP_USER",
+            "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/ssh/:/var/lib/mcp/.ssh:ro",
+            "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw",
             "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
           ],
           "env": {
@@ -104,7 +131,7 @@ The value for `command` will vary depending on how `linux-mcp-server` was instal
     }
     ```
 
-=== "Container (stdio transport)"
+=== "Container (Podman)"
 
     ```json
     {
@@ -121,6 +148,35 @@ The value for `command` will vary depending on how `linux-mcp-server` was instal
             "-v", "/home/YOUR_USER/.ssh/id_ed25519:/var/lib/mcp/.ssh/id_ed25519:ro,Z",
             "-v", "/home/YOUR_USER/.ssh/config:/var/lib/mcp/.ssh/config:ro,Z",
             "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw,Z",
+            "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
+          ],
+          "env": {
+            "LINUX_MCP_KEY_PASSPHRASE": "<secret>",
+            "LINUX_MCP_USER": "YOUR_USER"
+          }
+        }
+      }
+    }
+    ```
+
+    !!! warning "Replace Paths"
+        Replace `YOUR_USER` with your actual username and adjust paths as needed.
+
+=== "Container (Docker)"
+
+    ```json
+    {
+      "mcpServers": {
+        "Linux Tools": {
+          "command": "docker",
+          "args": [
+            "run",
+            "--rm",
+            "--interactive",
+            "-e", "LINUX_MCP_KEY_PASSPHRASE",
+            "-e", "LINUX_MCP_USER",
+            "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/ssh/:/var/lib/mcp/.ssh:ro",
+            "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw",
             "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
           ],
           "env": {
@@ -164,7 +220,7 @@ Edit `~/.codex/config.toml`:
     LINUX_MCP_USER = "your-ssh-username"
     ```
 
-=== "Container (stdio transport)"
+=== "Container (Podman)"
 
     ```toml
     [mcp_servers.linux-mcp-server]
@@ -177,6 +233,28 @@ Edit `~/.codex/config.toml`:
       "-v", "/home/YOUR_USER/.ssh/id_ed25519:/var/lib/mcp/.ssh/id_ed25519:ro,Z",
       "-v", "/home/YOUR_USER/.ssh/config:/var/lib/mcp/.ssh/config:ro,Z",
       "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw,Z",
+      "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
+    ]
+
+    [mcp_servers.linux-mcp-server.env]
+    LINUX_MCP_KEY_PASSPHRASE = "<secret>"
+    LINUX_MCP_USER = "YOUR_USER"
+    ```
+
+    !!! warning "Replace Paths"
+        Replace `YOUR_USER` with your actual username.
+
+=== "Container (Docker)"
+
+    ```toml
+    [mcp_servers.linux-mcp-server]
+    command = "docker"
+    args = [
+      "run", "--rm", "--interactive",
+      "-e", "LINUX_MCP_KEY_PASSPHRASE",
+      "-e", "LINUX_MCP_USER",
+      "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/ssh/:/var/lib/mcp/.ssh:ro",
+      "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw",
       "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
     ]
 
@@ -214,7 +292,7 @@ Edit `~/.cursor/mcp.json`:
     }
     ```
 
-=== "Container (stdio transport)"
+=== "Container (Podman)"
 
     ```json
     {
@@ -229,6 +307,33 @@ Edit `~/.cursor/mcp.json`:
             "-v", "/home/YOUR_USER/.ssh/id_ed25519:/var/lib/mcp/.ssh/id_ed25519:ro,Z",
             "-v", "/home/YOUR_USER/.ssh/config:/var/lib/mcp/.ssh/config:ro,Z",
             "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw,Z",
+            "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
+          ],
+          "env": {
+            "LINUX_MCP_KEY_PASSPHRASE": "<secret>",
+            "LINUX_MCP_USER": "YOUR_USER"
+          }
+        }
+      }
+    }
+    ```
+
+    !!! warning "Replace Paths"
+        Replace `YOUR_USER` with your actual username.
+
+=== "Container (Docker)"
+
+    ```json
+    {
+      "mcpServers": {
+        "linux-mcp-server": {
+          "command": "docker",
+          "args": [
+            "run", "--rm", "--interactive",
+            "-e", "LINUX_MCP_KEY_PASSPHRASE",
+            "-e", "LINUX_MCP_USER",
+            "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/ssh/:/var/lib/mcp/.ssh:ro",
+            "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw",
             "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
           ],
           "env": {
@@ -272,7 +377,7 @@ Edit `~/.gemini/settings.json`:
     !!! note "Merging with Existing Settings"
         If you have other settings in your `settings.json`, add the `mcpServers` object alongside them.
 
-=== "Container (stdio transport)"
+=== "Container (Podman)"
 
     ```json
     {
@@ -287,6 +392,33 @@ Edit `~/.gemini/settings.json`:
             "-v", "/home/YOUR_USER/.ssh/id_ed25519:/var/lib/mcp/.ssh/id_ed25519:ro,Z",
             "-v", "/home/YOUR_USER/.ssh/config:/var/lib/mcp/.ssh/config:ro,Z",
             "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw,Z",
+            "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
+          ],
+          "env": {
+            "LINUX_MCP_KEY_PASSPHRASE": "<secret>",
+            "LINUX_MCP_USER": "YOUR_USER"
+          }
+        }
+      }
+    }
+    ```
+
+    !!! warning "Replace Paths"
+        Replace `YOUR_USER` with your actual username.
+
+=== "Container (Docker)"
+
+    ```json
+    {
+      "mcpServers": {
+        "linux-mcp-server": {
+          "command": "docker",
+          "args": [
+            "run", "--rm", "--interactive",
+            "-e", "LINUX_MCP_KEY_PASSPHRASE",
+            "-e", "LINUX_MCP_USER",
+            "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/ssh/:/var/lib/mcp/.ssh:ro",
+            "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw",
             "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
           ],
           "env": {
@@ -331,7 +463,7 @@ The Goose desktop app provides a wizard for adding extensions:
 5. Click **Add** to save the extension
 
 !!! tip "Container Installation"
-    For container-based installs, set **Command** to `podman` and add the container arguments in the **Arguments** field (one per line).
+    For container-based installs, set **Command** to `podman` or `docker` and add the container arguments in the **Arguments** field (one per line).
 
 ### YAML Configuration (CLI)
 
@@ -357,7 +489,7 @@ If you prefer editing config files directly, add to `~/.config/goose/config.yaml
         args: []
     ```
 
-=== "Container (stdio transport)"
+=== "Container (Podman)"
 
     ```yaml
     extensions:
@@ -392,6 +524,39 @@ If you prefer editing config files directly, add to `~/.config/goose/config.yaml
         bundled: null
         available_tools: []
     ```
+
+=== "Container (Docker)"
+
+    ```yaml
+    extensions:
+      linux-tools:
+        enabled: true
+        type: stdio
+        name: linux-tools
+        description: Linux tools
+        cmd: docker
+        args:
+          - run
+          - --rm
+          - --interactive
+          - -e
+          - LINUX_MCP_KEY_PASSPHRASE
+          - -e
+          - LINUX_MCP_USER
+          - -v
+          - /home/YOUR_USER/.local/share/linux-mcp-server/ssh/:/var/lib/mcp/.ssh:ro
+          - -v
+          - /home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw
+          - quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest
+        envs: {}
+        env_keys:
+          - LINUX_MCP_KEY_PASSPHRASE
+          - LINUX_MCP_USER
+        timeout: 30
+        bundled: null
+        available_tools: []
+    ```
+
 === "HTTP transport"
 
     !!! warning "HTTP Transport Security"
@@ -447,7 +612,7 @@ Edit `~/.config/opencode/opencode.json`:
     }
     ```
 
-=== "Container (stdio transport)"
+=== "Container (Podman)"
 
     ```json
     {
@@ -463,6 +628,35 @@ Edit `~/.config/opencode/opencode.json`:
             "-v", "/home/YOUR_USER/.ssh/id_ed25519:/var/lib/mcp/.ssh/id_ed25519:ro,Z",
             "-v", "/home/YOUR_USER/.ssh/config:/var/lib/mcp/.ssh/config:ro,Z",
             "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw,Z",
+            "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
+          ],
+          "enabled": true,
+          "env": {
+            "LINUX_MCP_KEY_PASSPHRASE": "<secret>",
+            "LINUX_MCP_USER": "YOUR_USER"
+          }
+        }
+      }
+    }
+    ```
+
+    !!! warning "Replace Paths"
+        Replace `YOUR_USER` with your actual username.
+
+=== "Container (Docker)"
+
+    ```json
+    {
+      "$schema": "https://opencode.ai/config.json",
+      "mcp": {
+        "linux-mcp-server": {
+          "type": "local",
+          "command": [
+            "docker", "run", "--rm", "--interactive",
+            "-e", "LINUX_MCP_KEY_PASSPHRASE",
+            "-e", "LINUX_MCP_USER",
+            "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/ssh/:/var/lib/mcp/.ssh:ro",
+            "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw",
             "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
           ],
           "enabled": true,
@@ -504,7 +698,7 @@ Add to your VS Code `mcp.json`:
     }
     ```
 
-=== "Container (stdio transport)"
+=== "Container (Podman)"
 
     ```json
     {
@@ -519,6 +713,33 @@ Add to your VS Code `mcp.json`:
             "-v", "/home/YOUR_USER/.ssh/id_ed25519:/var/lib/mcp/.ssh/id_ed25519:ro,Z",
             "-v", "/home/YOUR_USER/.ssh/config:/var/lib/mcp/.ssh/config:ro,Z",
             "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw,Z",
+            "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
+          ],
+          "env": {
+            "LINUX_MCP_KEY_PASSPHRASE": "<secret>",
+            "LINUX_MCP_USER": "YOUR_USER"
+          }
+        }
+      }
+    }
+    ```
+
+    !!! warning "Replace Paths"
+        Replace `YOUR_USER` with your actual username.
+
+=== "Container (Docker)"
+
+    ```json
+    {
+      "servers": {
+        "linux-mcp-server": {
+          "command": "docker",
+          "args": [
+            "run", "--rm", "--interactive",
+            "-e", "LINUX_MCP_KEY_PASSPHRASE",
+            "-e", "LINUX_MCP_USER",
+            "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/ssh/:/var/lib/mcp/.ssh:ro",
+            "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw",
             "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
           ],
           "env": {
@@ -562,7 +783,7 @@ Edit `~/.codeium/windsurf/mcp_config.json`:
     }
     ```
 
-=== "Container (stdio transport)"
+=== "Container (Podman)"
 
     ```json
     {
@@ -577,6 +798,33 @@ Edit `~/.codeium/windsurf/mcp_config.json`:
             "-v", "/home/YOUR_USER/.ssh/id_ed25519:/var/lib/mcp/.ssh/id_ed25519:ro,Z",
             "-v", "/home/YOUR_USER/.ssh/config:/var/lib/mcp/.ssh/config:ro,Z",
             "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw,Z",
+            "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
+          ],
+          "env": {
+            "LINUX_MCP_KEY_PASSPHRASE": "<secret>",
+            "LINUX_MCP_USER": "YOUR_USER"
+          }
+        }
+      }
+    }
+    ```
+
+    !!! warning "Replace Paths"
+        Replace `YOUR_USER` with your actual username.
+
+=== "Container (Docker)"
+
+    ```json
+    {
+      "mcpServers": {
+        "linux-mcp-server": {
+          "command": "docker",
+          "args": [
+            "run", "--rm", "--interactive",
+            "-e", "LINUX_MCP_KEY_PASSPHRASE",
+            "-e", "LINUX_MCP_USER",
+            "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/ssh/:/var/lib/mcp/.ssh:ro",
+            "-v", "/home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw",
             "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest"
           ],
           "env": {

--- a/docs/install.md
+++ b/docs/install.md
@@ -50,77 +50,47 @@ sudo dnf install linux-mcp-server
 
 ---
 
-## Run in a container (Podman)
+## Run in a container
 
-A container runtime such as [Podman](https://podman-desktop.io) is required.
+Instead of installing the Python code for linux-mcp-server directly on your system, you can run
+the MCP server from a prebuilt container instead.  A container runtime such as [Podman](https://podman-desktop.io)
+(recommended) or [Docker](https://docs.docker.com/desktop/) is required.
 
 **Container image:**
 ```
 quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest
 ```
 
-See [Client Configuration](clients.md) for examples of how to run the container using stdio transport.
+### Container Setup (Podman)
 
-When using an HTTP transport, the container must be started before launching the MCP client:
+Before running linux-mcp-server with podman, we need to create the directory where
+the logs will be stored:
 
 ```bash
-podman run --rm --interactive \
-  --userns "keep-id:uid=1001,gid=0" \
-  --port 8000:8000 \
-  -e LINUX_MCP_KEY_PASSPHRASE \
-  -e LINUX_MCP_TRANSPORT=http \
-  -e LINUX_MCP_HOST=0.0.0.0 \
-  -v /home/YOUR_USER/.ssh/id_ed25519:/var/lib/mcp/.ssh/id_ed25519:ro \
-  -v /home/YOUR_USER/.ssh/config:/var/lib/mcp/.ssh/config:ro,Z \
-  -v /home/YOUR_USER/.local/share/linux-mcp-server/logs:/var/lib/mcp/.local/share/linux-mcp-server/logs:rw \
-  quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:latest
+mkdir -p ~/.local/share/linux-mcp-server/logs
 ```
 
-### Container Setup for SSH Keys
+### Container Setup (Docker)
 
-The container needs access to your SSH keys for remote connections. Set up the required directories and permissions:
+When running linux-mcp-server with docker, the container runs as a non-root user (UID 1001).
+Files mounted from your host must be readable by this user.
+
+The container needs access to your SSH keys for remote connections. You'll need to make a copy that is readable by the container:
 
 ```bash
 # Create directories
-mkdir -p ~/.local/share/linux-mcp-server/logs
+mkdir -p ~/.local/share/linux-mcp-server/{logs,ssh}
 
-# Copy your SSH key and set ownership
-cp ~/.ssh/id_ed25519 ~/.local/share/linux-mcp-server/
+# Copy your SSH keys/configs and set ownership (exact files will vary)
+cp ~/.ssh/config ~/.local/share/linux-mcp-server/ssh/config
+cp ~/.ssh/id_ed25519 ~/.local/share/linux-mcp-server/ssh
 sudo chown -R 1001:1001 ~/.local/share/linux-mcp-server/
 ```
 
-??? info "Why UID 1001? Understanding container permissions"
+## Configuring your client
 
-    **The container runs as a non-root user** (UID 1001) for security. Files mounted from your host must be readable by this user.
+See [Client Configuration](clients.md) for specific examples. Make sure to modify the provided podman or docker command lines to have the correct paths.
 
-    **What's happening:**
-
-    - The container process runs as user ID `1001`, not your host user
-    - Mounted SSH keys must be owned by `1001` to be readable
-    - Log directory must be writable by `1001` to store logs
-
-    **If you see permission errors:**
-
-    ```bash
-    # Check current ownership
-    ls -la ~/.local/share/linux-mcp-server/
-
-    # Fix ownership (should show 1001 as owner)
-    sudo chown -R 1001:1001 ~/.local/share/linux-mcp-server/
-    ```
-
-??? warning "Docker vs Podman differences"
-
-    **Podman** uses `--userns keep-id:uid=1001,gid=0` to map user namespaces.
-
-    **Docker** does NOT support this flag. When using Docker:
-
-    - Remove the `--userns` parameter from the run command
-    - Ensure files are owned by UID 1001 on the host
-    - Create directories beforehand (Docker won't auto-create them)
-
-
-Once the SSH keys are configured, configure your [MCP client](clients.md) to run the container image. It is not necessary to run the container manually since the MCP client will do that.
 
 ---
 


### PR DESCRIPTION
The documentation mixed together Podman and Docker specifics in a quite confusing way. Split things apart into instructions for Podman (using --userns=keep-id) and Docker (changing ownership of files to 1001).

Remove the example of running the server locally with a HTTP transport - we now require an auth_policy.json for the HTTP transport, so it no longer works at all, and it's also not something that we want to support.