### PR TITLE
Improve Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,13 +3,46 @@
   "extends": ["github>rhel-lightspeed/renovate-config"],
   "packageRules": [
     {
-      "matchManagers": ["pep621", "pip_requirements", "pip-compile", "poetry", "pipenv"],
+      "description": "Group other non-major updates not explicitly grouped",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "other non-major updates",
+      "groupSlug": "other-non-major"
+    },
+    {
+      "description": "Only update uv.lock for Python packages",
+      "matchManagers": [
+        "pep621",
+        "pip_requirements",
+        "pip-compile",
+        "poetry",
+        "pipenv"
+      ],
       "rangeStrategy": "in-range-only"
     },
     {
+      "description": "Group most non-major updates to Python packages",
+      "matchManagers": [
+        "pep621",
+        "pip_requirements",
+        "pip-compile",
+        "poetry",
+        "pipenv"
+      ],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "excludePackageNames": ["fastmcp", "litellm"],
+      "groupName": "non-major Python updates",
+      "groupSlug": "python-non-major"
+    },
+    {
+      "description": "Exclude FastMCP and LiteLLM from grouping",
+      "matchPackageNames": ["fastmcp", "litellm"],
+      "groupName": null
+    },
+    {
+      "description": "Group updates to NPM packages used to build our mcp-app",
       "matchManagers": ["npm"],
-      "groupName": "mcp-app npm dependencies",
-      "schedule": ["before 9am on monday"]
+      "groupName": "mcp-app NPM updates",
+      "groupSlug": "mcp-app-npm"
     }
   ]
 }


### PR DESCRIPTION
Switch from JSON to YAML for readability and group updates as follows:

 - FastMCP
 - LiteLLM
 - Other Python Packages
 - mcp-app NPM dependencies
 - Everything else

Override schedule:weekends from the rhel-lightspeed shared config with schedule:weekly to line up with the weekly lockfile maintenance and avoid unnecessary middle-of-the-weekend email notifications.