### PR TITLE
Update codecov/codecov-action 7.0.0 to fix failing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         run: uv run --locked pytest --cov-report=xml
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@v7.0.0
         with:
           env_vars: OS,PYTHON
           disable_search: true


### PR DESCRIPTION
6.0.1 tries to download a GPG key from a missing keybase account, causing our CI actions to fail when they try to upload the coverage report.

See: https://github.com/codecov/wrapper/pull/75