### PR TITLE
Containerfile: Add a release_type label to control floating tag

### DIFF
--- a/.tekton/pipeline-build-multiarch.yaml
+++ b/.tekton/pipeline-build-multiarch.yaml
@@ -244,6 +244,7 @@ spec:
             - $(params.build-args[*])
             - PSEUDO_VERSION=$(tasks.get-version.results.pseudo_version)
             - VERSION=$(tasks.get-version.results.version)
+            - RELEASE_TYPE=$(tasks.get-version.results.release_type)
 
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)

--- a/.tekton/task-get-version.yaml
+++ b/.tekton/task-get-version.yaml
@@ -18,6 +18,9 @@ spec:
     - name: version
       description: Version that is also a valid container tag
 
+    - name: release_type
+      description: Floating tag we should use for this release (latest/dev)
+
   volumes:
     - name: workdir
       emptyDir: {}
@@ -57,5 +60,12 @@ spec:
         pseudo_version="$(hatch version)"
         version="${pseudo_version%%+*}"
 
+        if [[ "$pseudo_version" == *dev* ]]; then
+          release_type="dev"
+        else
+          release_type="latest"
+        fi
+
         echo -n "$pseudo_version" | tee "$(results.pseudo_version.path)"
         echo -n "$version" | tee "$(results.version.path)"
+        echo -n "$release_type" | tee "$(results.release_type.path)"

--- a/Containerfile
+++ b/Containerfile
@@ -57,6 +57,7 @@ ARG UID=1001
 ARG SOURCE_DATE_EPOCH
 ARG PSEUDO_VERSION=0.1.0a
 ARG VERSION=0.1.0a
+ARG RELEASE_TYPE=dev
 
 # Indicator the application is running in a container
 ENV container=docker
@@ -83,6 +84,7 @@ LABEL summary="Linux MCP Server"
 LABEL url="https://github.com/rhel-lightspeed/linux-mcp-server"
 LABEL vendor="Red Hat, Inc."
 LABEL version=${VERSION}
+LABEL release_type=${RELEASE_TYPE}
 
 ADD licenses/ /licenses/
 ADD LICENSE /licenses/Apache-2.0.txt


### PR DESCRIPTION
We currently tag every single build - whether from a tagged release or not as `:latest` in our Konflux-backed quay.io builds. To allow us to only label tagged releases with the `:latest` tag add a label to the Containerfile that is `latest` (for a tagged release) and `dev` otherwise.