### PR TITLE
[RSPEED-2265] Convert network tools to structured output

### DIFF
--- a/src/linux_mcp_server/formatters.py
+++ b/src/linux_mcp_server/formatters.py
@@ -6,9 +6,7 @@ human-readable strings for tool output.
 
 from linux_mcp_server.models import ListeningPort
 from linux_mcp_server.models import NetworkConnection
-from linux_mcp_server.models import NetworkInterface
 from linux_mcp_server.models import ProcessInfo
-from linux_mcp_server.utils import format_bytes
 
 
 def format_network_connections(
@@ -101,41 +99,6 @@ def format_process_list(
     lines.append(f"\n\nTotal processes: {len(processes)}")
     if max_display is not None and len(processes) > max_display:
         lines.append(f"Showing: First {max_display} processes")
-
-    return "\n".join(lines)
-
-
-def format_network_interfaces(
-    interfaces: dict[str, NetworkInterface],
-    stats: dict[str, NetworkInterface] | None = None,
-) -> str:
-    """Format network interface information into a readable string.
-
-    Args:
-        interfaces: Dictionary of interface name to NetworkInterface objects.
-        stats: Optional dictionary of interface statistics.
-
-    Returns:
-        Formatted string representation.
-    """
-    lines = ["=== Network Interfaces ===\n"]
-
-    for name, iface in sorted(interfaces.items()):
-        lines.append(f"\n{name}:")
-        if iface.status:
-            lines.append(f"  Status: {iface.status}")
-        for addr in iface.addresses:
-            lines.append(f"  Address: {addr}")
-
-        # Add stats if available
-        if stats and name in stats:
-            stat = stats[name]
-            lines.append(f"  RX: {format_bytes(stat.rx_bytes)} ({stat.rx_packets} packets)")
-            lines.append(f"  TX: {format_bytes(stat.tx_bytes)} ({stat.tx_packets} packets)")
-            if stat.rx_errors or stat.tx_errors:
-                lines.append(f"  Errors: RX={stat.rx_errors}, TX={stat.tx_errors}")
-            if stat.rx_dropped or stat.tx_dropped:
-                lines.append(f"  Dropped: RX={stat.rx_dropped}, TX={stat.tx_dropped}")
 
     return "\n".join(lines)
 

--- a/src/linux_mcp_server/formatters.py
+++ b/src/linux_mcp_server/formatters.py
@@ -4,33 +4,7 @@ This module provides functions to format parsed data into
 human-readable strings for tool output.
 """
 
-from linux_mcp_server.models import ListeningPort
 from linux_mcp_server.models import ProcessInfo
-
-
-def format_listening_ports(
-    ports: list[ListeningPort],
-    header: str = "=== Listening Ports ===\n",
-) -> str:
-    """Format listening ports into a readable string.
-
-    Args:
-        ports: List of ListeningPort objects.
-        header: Header text for the output.
-
-    Returns:
-        Formatted string representation.
-    """
-    lines = [header]
-    lines.append(f"{'Proto':<8} {'Local Address':<30} {'Status':<15} {'PID/Program'}")
-    lines.append("-" * 80)
-
-    for port in ports:
-        local = f"{port.local_address}:{port.local_port}"
-        lines.append(f"{port.protocol:<8} {local:<30} {'LISTEN':<15} {port.process}")
-
-    lines.append(f"\n\nTotal listening ports: {len(ports)}")
-    return "\n".join(lines)
 
 
 def format_process_list(

--- a/src/linux_mcp_server/formatters.py
+++ b/src/linux_mcp_server/formatters.py
@@ -5,34 +5,7 @@ human-readable strings for tool output.
 """
 
 from linux_mcp_server.models import ListeningPort
-from linux_mcp_server.models import NetworkConnection
 from linux_mcp_server.models import ProcessInfo
-
-
-def format_network_connections(
-    connections: list[NetworkConnection],
-    header: str = "=== Active Network Connections ===\n",
-) -> str:
-    """Format network connections into a readable string.
-
-    Args:
-        connections: List of NetworkConnection objects.
-        header: Header text for the output.
-
-    Returns:
-        Formatted string representation.
-    """
-    lines = [header]
-    lines.append(f"{'Proto':<8} {'Local Address':<30} {'Remote Address':<30} {'Status':<15} {'PID/Program'}")
-    lines.append("-" * 110)
-
-    for conn in connections:
-        local = f"{conn.local_address}:{conn.local_port}"
-        remote = f"{conn.remote_address}:{conn.remote_port}" if conn.remote_address else "N/A"
-        lines.append(f"{conn.protocol:<8} {local:<30} {remote:<30} {conn.state:<15} {conn.process}")
-
-    lines.append(f"\n\nTotal connections: {len(connections)}")
-    return "\n".join(lines)
 
 
 def format_listening_ports(

--- a/src/linux_mcp_server/parsers.py
+++ b/src/linux_mcp_server/parsers.py
@@ -280,6 +280,42 @@ def parse_ip_brief(stdout: str) -> dict[str, NetworkInterface]:
     return interfaces
 
 
+def merge_network_interfaces(
+    interfaces: dict[str, NetworkInterface],
+    stats: dict[str, NetworkInterface] | None = None,
+) -> list[NetworkInterface]:
+    """Merge interface address info with traffic statistics.
+
+    Args:
+        interfaces: Interface address/status info keyed by name.
+        stats: Optional traffic statistics keyed by name.
+
+    Returns:
+        Sorted list of merged NetworkInterface objects.
+    """
+    if stats is None:
+        stats = {}
+
+    merged: list[NetworkInterface] = []
+    for name, iface in sorted(interfaces.items()):
+        if name in stats:
+            stat = stats[name]
+            iface = iface.model_copy(
+                update={
+                    "rx_bytes": stat.rx_bytes,
+                    "tx_bytes": stat.tx_bytes,
+                    "rx_packets": stat.rx_packets,
+                    "tx_packets": stat.tx_packets,
+                    "rx_errors": stat.rx_errors,
+                    "tx_errors": stat.tx_errors,
+                    "rx_dropped": stat.rx_dropped,
+                    "tx_dropped": stat.tx_dropped,
+                }
+            )
+        merged.append(iface)
+    return merged
+
+
 def parse_system_info(results: dict[str, str]) -> SystemInfo:
     """Parse system info command results into SystemInfo object.
 

--- a/src/linux_mcp_server/tools/network.py
+++ b/src/linux_mcp_server/tools/network.py
@@ -1,11 +1,12 @@
 """Network diagnostic tools."""
 
+from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from linux_mcp_server.audit import log_tool_call
 from linux_mcp_server.commands import get_command
 from linux_mcp_server.formatters import format_listening_ports
-from linux_mcp_server.formatters import format_network_connections
+from linux_mcp_server.models import NetworkConnection
 from linux_mcp_server.models import NetworkInterface
 from linux_mcp_server.parsers import merge_network_interfaces
 from linux_mcp_server.parsers import parse_ip_brief
@@ -64,7 +65,7 @@ async def get_network_interfaces(
 @disallow_local_execution_in_containers
 async def get_network_connections(
     host: Host = None,
-) -> str:
+) -> list[NetworkConnection]:
     """Get active network connections.
 
     Retrieves all established and pending network connections including protocol,
@@ -75,9 +76,8 @@ async def get_network_connections(
     returncode, stdout, stderr = await cmd.run(host=host)
 
     if is_successful_output(returncode, stdout):
-        connections = parse_ss_connections(stdout)
-        return format_network_connections(connections)
-    return f"Error getting network connections: return code {returncode}, stderr: {stderr}"
+        return parse_ss_connections(stdout)
+    raise ToolError(f"Error getting network connections: return code {returncode}, stderr: {stderr}")
 
 
 @mcp.tool(

--- a/src/linux_mcp_server/tools/network.py
+++ b/src/linux_mcp_server/tools/network.py
@@ -6,7 +6,8 @@ from linux_mcp_server.audit import log_tool_call
 from linux_mcp_server.commands import get_command
 from linux_mcp_server.formatters import format_listening_ports
 from linux_mcp_server.formatters import format_network_connections
-from linux_mcp_server.formatters import format_network_interfaces
+from linux_mcp_server.models import NetworkInterface
+from linux_mcp_server.parsers import merge_network_interfaces
 from linux_mcp_server.parsers import parse_ip_brief
 from linux_mcp_server.parsers import parse_proc_net_dev
 from linux_mcp_server.parsers import parse_ss_connections
@@ -27,7 +28,7 @@ from linux_mcp_server.utils.validation import is_successful_output
 @disallow_local_execution_in_containers
 async def get_network_interfaces(
     host: Host = None,
-) -> str:
+) -> list[NetworkInterface]:
     """Get network interface information.
 
     Retrieves all network interfaces with their operational state, IP addresses,
@@ -50,7 +51,7 @@ async def get_network_interfaces(
     if is_successful_output(returncode, stdout):
         stats = parse_proc_net_dev(stdout)
 
-    return format_network_interfaces(interfaces, stats)
+    return merge_network_interfaces(interfaces, stats)
 
 
 @mcp.tool(

--- a/src/linux_mcp_server/tools/network.py
+++ b/src/linux_mcp_server/tools/network.py
@@ -5,7 +5,7 @@ from mcp.types import ToolAnnotations
 
 from linux_mcp_server.audit import log_tool_call
 from linux_mcp_server.commands import get_command
-from linux_mcp_server.formatters import format_listening_ports
+from linux_mcp_server.models import ListeningPort
 from linux_mcp_server.models import NetworkConnection
 from linux_mcp_server.models import NetworkInterface
 from linux_mcp_server.parsers import merge_network_interfaces
@@ -90,7 +90,7 @@ async def get_network_connections(
 @disallow_local_execution_in_containers
 async def get_listening_ports(
     host: Host = None,
-) -> str:
+) -> list[ListeningPort]:
     """Get listening ports.
 
     Retrieves all ports with services actively listening for connections,
@@ -101,6 +101,5 @@ async def get_listening_ports(
     returncode, stdout, stderr = await cmd.run(host=host)
 
     if is_successful_output(returncode, stdout):
-        ports = parse_ss_listening(stdout)
-        return format_listening_ports(ports)
-    return f"Error getting listening ports: return code {returncode}, stderr: {stderr}"
+        return parse_ss_listening(stdout)
+    raise ToolError(f"Error getting listening ports: return code {returncode}, stderr: {stderr}")

--- a/tests/functional/network_diagnostics/test_get_listening_ports.py
+++ b/tests/functional/network_diagnostics/test_get_listening_ports.py
@@ -7,22 +7,18 @@ async def test_listening_ports(mcp_session):
     """
     Verify that the server lists correctly all the available listening ports.
     """
-
     response = await mcp_session.call_tool("get_listening_ports")
     assert response is not None
 
-    mcp_output = response.content[0].text
-    shell_output = shell("ss -tulnp", silent=True).stdout.strip()
+    content = response.structured_content["result"]
+    assert content is not None
 
-    assert "=== Listening Ports ===" in mcp_output
-    assert "Proto" in mcp_output
-    assert "Local Address" in mcp_output
+    mcp_locals = {f"{port['local_address']}:{port['local_port']}" for port in content}
+    shell_output = shell("ss -tulnp", silent=True).stdout.strip()
     shell_lines = [line for line in shell_output.split("\n")[1:] if line.strip()]
-    expected_count = len(shell_lines)
-    assert f"Total listening ports: {expected_count}" in mcp_output
 
     for line in shell_lines:
         parts = line.split()
         if len(parts) >= 5:
             local_addr = parts[4]
-            assert local_addr in mcp_output, f"Listening port {local_addr} not found in MCP output"
+            assert local_addr in mcp_locals, f"Listening port {local_addr} not found in structured output"

--- a/tests/functional/network_diagnostics/test_get_network_connections.py
+++ b/tests/functional/network_diagnostics/test_get_network_connections.py
@@ -10,17 +10,12 @@ async def test_network_connections(mcp_session):
     response = await mcp_session.call_tool("get_network_connections")
     assert response is not None
 
-    mcp_output = response.content[0].text
-    shell_output = shell("ss -tunap", silent=True).stdout.strip()
-    assert "=== Active Network Connections ===" in mcp_output
-    assert "Proto" in mcp_output
-    assert "Local Address" in mcp_output
-    assert "Remote Address" in mcp_output
-    assert "Status" in mcp_output
+    content = response.structured_content["result"]
+    assert content is not None
 
+    mcp_locals = {f"{conn['local_address']}:{conn['local_port']}" for conn in content}
+    shell_output = shell("ss -tunap", silent=True).stdout.strip()
     shell_lines = [line for line in shell_output.split("\n")[1:] if line.strip()]
-    # Verify the output has a total connections line (count may slightly vary due to transient connections)
-    assert "Total connections:" in mcp_output
 
     found_count = 0
     total_checked = 0
@@ -28,11 +23,9 @@ async def test_network_connections(mcp_session):
         parts = line.split()
         if len(parts) >= 5:
             total_checked += 1
-            # Column 4 is Local Address:Port in ss -tunap output
             local_addr = parts[4]
-            if local_addr in mcp_output:
+            if local_addr in mcp_locals:
                 found_count += 1
 
     if total_checked > 0:
-        # At least 80% of connections should match between the two calls
         assert found_count >= total_checked * 0.8, f"Only {found_count} out of {total_checked} connections matched"

--- a/tests/functional/network_diagnostics/test_get_network_interfaces.py
+++ b/tests/functional/network_diagnostics/test_get_network_interfaces.py
@@ -14,10 +14,13 @@ async def test_network_interfaces(mcp_session):
 
     actual_network_interfaces = shell("ip -j a", silent=True).stdout.strip()
     interfaces = json.loads(actual_network_interfaces)
+    content = response.structured_content["result"]
+    assert content is not None
+
+    content_by_name = {iface["name"]: iface for iface in content}
+
     for iface in interfaces:
         if iface["link_type"] == "loopback":
-            # Skip the loopback as it has different attributes
-            # (I did not want to parse them now)
             continue
         name = iface["ifname"]
         status = iface["operstate"]
@@ -30,7 +33,8 @@ async def test_network_interfaces(mcp_session):
                     addresses.append(f"{addr['local']}/{addr['prefixlen']}")
 
         assert addresses, f"No addresses found for interface {name}"
-        matching_string = f"{name}:\n  Status: {status}\n"
-        matching_string += "\n".join(f"  Address: {address}" for address in addresses)
-
-        assert matching_string in response.content[0].text
+        assert name in content_by_name, f"Interface {name} not found in structured output"
+        result_iface = content_by_name[name]
+        assert result_iface["status"] == status
+        for address in addresses:
+            assert address in result_iface["addresses"]

--- a/tests/parsers/test_merge_network_interfaces.py
+++ b/tests/parsers/test_merge_network_interfaces.py
@@ -1,0 +1,70 @@
+from linux_mcp_server.models import NetworkInterface
+from linux_mcp_server.parsers import merge_network_interfaces
+
+
+def test_merge_network_interfaces_empty():
+    """Test merging with no inputs."""
+    assert merge_network_interfaces({}) == []
+    assert merge_network_interfaces({}, {}) == []
+
+
+def test_merge_network_interfaces_interfaces_only():
+    """Test merging when only address info is available."""
+    interfaces = {
+        "eth0": NetworkInterface(name="eth0", status="UP", addresses=["192.168.1.100/24"]),
+        "lo": NetworkInterface(name="lo", status="UNKNOWN", addresses=["127.0.0.1/8"]),
+    }
+
+    result = merge_network_interfaces(interfaces)
+
+    assert len(result) == 2
+    assert result[0].name == "eth0"
+    assert result[0].status == "UP"
+    assert result[0].addresses == ["192.168.1.100/24"]
+    assert result[0].rx_bytes == 0
+    assert result[1].name == "lo"
+
+
+def test_merge_network_interfaces_with_stats():
+    """Test merging address info with traffic statistics."""
+    interfaces = {
+        "eth0": NetworkInterface(name="eth0", status="UP", addresses=["192.168.1.100/24"]),
+    }
+    stats = {
+        "eth0": NetworkInterface(
+            name="eth0",
+            rx_bytes=1000000,
+            tx_bytes=500000,
+            rx_packets=10000,
+            tx_packets=5000,
+            rx_errors=10,
+            tx_errors=5,
+            rx_dropped=2,
+            tx_dropped=1,
+        ),
+    }
+
+    result = merge_network_interfaces(interfaces, stats)
+
+    assert len(result) == 1
+    iface = result[0]
+    assert iface.name == "eth0"
+    assert iface.status == "UP"
+    assert iface.addresses == ["192.168.1.100/24"]
+    assert iface.rx_bytes == 1000000
+    assert iface.tx_bytes == 500000
+    assert iface.rx_packets == 10000
+    assert iface.tx_packets == 5000
+    assert iface.rx_errors == 10
+    assert iface.tx_errors == 5
+    assert iface.rx_dropped == 2
+    assert iface.tx_dropped == 1
+
+
+def test_merge_network_interfaces_stats_only_ignored():
+    """Test that stats-only interfaces are not included."""
+    stats = {
+        "eth0": NetworkInterface(name="eth0", rx_bytes=1000, tx_bytes=500),
+    }
+
+    assert merge_network_interfaces({}, stats) == []

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -2,40 +2,12 @@
 
 from linux_mcp_server.formatters import format_disk_usage
 from linux_mcp_server.formatters import format_hardware_info
-from linux_mcp_server.formatters import format_listening_ports
 from linux_mcp_server.formatters import format_process_detail
 from linux_mcp_server.formatters import format_process_list
 from linux_mcp_server.formatters import format_service_logs
 from linux_mcp_server.formatters import format_service_status
 from linux_mcp_server.formatters import format_services_list
-from linux_mcp_server.models import ListeningPort
 from linux_mcp_server.models import ProcessInfo
-
-
-class TestFormatListeningPorts:
-    """Tests for format_listening_ports function."""
-
-    def test_format_empty_list(self):
-        """Test formatting an empty list."""
-        result = format_listening_ports([])
-        assert "=== Listening Ports ===" in result
-        assert "Total listening ports: 0" in result
-
-    def test_format_single_port(self):
-        """Test formatting a single listening port."""
-        ports = [
-            ListeningPort(
-                protocol="TCP",
-                local_address="0.0.0.0",
-                local_port="22",
-                process="sshd",
-            )
-        ]
-        result = format_listening_ports(ports)
-        assert "TCP" in result
-        assert "0.0.0.0:22" in result
-        assert "LISTEN" in result
-        assert "Total listening ports: 1" in result
 
 
 class TestFormatProcessList:

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -4,7 +4,6 @@ from linux_mcp_server.formatters import format_disk_usage
 from linux_mcp_server.formatters import format_hardware_info
 from linux_mcp_server.formatters import format_listening_ports
 from linux_mcp_server.formatters import format_network_connections
-from linux_mcp_server.formatters import format_network_interfaces
 from linux_mcp_server.formatters import format_process_detail
 from linux_mcp_server.formatters import format_process_list
 from linux_mcp_server.formatters import format_service_logs
@@ -12,7 +11,6 @@ from linux_mcp_server.formatters import format_service_status
 from linux_mcp_server.formatters import format_services_list
 from linux_mcp_server.models import ListeningPort
 from linux_mcp_server.models import NetworkConnection
-from linux_mcp_server.models import NetworkInterface
 from linux_mcp_server.models import ProcessInfo
 
 
@@ -129,52 +127,6 @@ class TestFormatProcessList:
         result = format_process_list(processes, max_display=100)
         assert "Total processes: 150" in result
         assert "Showing: First 100 processes" in result
-
-
-class TestFormatNetworkInterfaces:
-    """Tests for format_network_interfaces function."""
-
-    def test_format_empty_interfaces(self):
-        """Test formatting empty interfaces."""
-        result = format_network_interfaces({})
-        assert "=== Network Interfaces ===" in result
-
-    def test_format_with_interfaces(self):
-        """Test formatting with interfaces."""
-        interfaces = {
-            "eth0": NetworkInterface(
-                name="eth0",
-                status="UP",
-                addresses=["192.168.1.100/24"],
-            ),
-            "lo": NetworkInterface(
-                name="lo",
-                status="UNKNOWN",
-                addresses=["127.0.0.1/8"],
-            ),
-        }
-        result = format_network_interfaces(interfaces)
-        assert "eth0:" in result
-        assert "Status: UP" in result
-        assert "192.168.1.100/24" in result
-
-    def test_format_with_stats(self):
-        """Test formatting with statistics."""
-        interfaces = {
-            "eth0": NetworkInterface(name="eth0", status="UP"),
-        }
-        stats = {
-            "eth0": NetworkInterface(
-                name="eth0",
-                rx_bytes=1000000,
-                tx_bytes=500000,
-                rx_packets=10000,
-                tx_packets=5000,
-            ),
-        }
-        result = format_network_interfaces(interfaces, stats)
-        assert "RX:" in result
-        assert "TX:" in result
 
 
 class TestFormatProcessDetail:

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -3,50 +3,13 @@
 from linux_mcp_server.formatters import format_disk_usage
 from linux_mcp_server.formatters import format_hardware_info
 from linux_mcp_server.formatters import format_listening_ports
-from linux_mcp_server.formatters import format_network_connections
 from linux_mcp_server.formatters import format_process_detail
 from linux_mcp_server.formatters import format_process_list
 from linux_mcp_server.formatters import format_service_logs
 from linux_mcp_server.formatters import format_service_status
 from linux_mcp_server.formatters import format_services_list
 from linux_mcp_server.models import ListeningPort
-from linux_mcp_server.models import NetworkConnection
 from linux_mcp_server.models import ProcessInfo
-
-
-class TestFormatNetworkConnections:
-    """Tests for format_network_connections function."""
-
-    def test_format_empty_list(self):
-        """Test formatting an empty list."""
-        result = format_network_connections([])
-        assert "=== Active Network Connections ===" in result
-        assert "Total connections: 0" in result
-
-    def test_format_single_connection(self):
-        """Test formatting a single connection."""
-        connections = [
-            NetworkConnection(
-                protocol="TCP",
-                state="ESTABLISHED",
-                local_address="192.168.1.100",
-                local_port="22",
-                remote_address="192.168.1.1",
-                remote_port="54321",
-                process="sshd",
-            )
-        ]
-        result = format_network_connections(connections)
-        assert "TCP" in result
-        assert "192.168.1.100:22" in result
-        assert "192.168.1.1:54321" in result
-        assert "ESTABLISHED" in result
-        assert "Total connections: 1" in result
-
-    def test_format_custom_header(self):
-        """Test formatting with custom header."""
-        result = format_network_connections([], header="=== Custom Header ===\n")
-        assert "=== Custom Header ===" in result
 
 
 class TestFormatListeningPorts:

--- a/tests/tools/test_network.py
+++ b/tests/tools/test_network.py
@@ -120,35 +120,41 @@ class TestGetNetworkConnections:
     """Test get_network_connections function."""
 
     @pytest.mark.parametrize(
-        ("host", "mock_output", "expected_content"),
+        ("host", "mock_output", "expected_count", "expected_local"),
         [
             pytest.param(
                 None,
                 """Netid  State      Recv-Q Send-Q Local Address:Port   Peer Address:Port
 tcp    ESTAB      0      0      192.168.1.100:22     192.168.1.1:54321
 tcp    LISTEN     0      128    0.0.0.0:80           0.0.0.0:*""",
-                ["192.168.1.100", "Total connections: 2"],
+                2,
+                "192.168.1.100:22",
                 id="local",
             ),
             pytest.param(
                 "remote.host",
                 """Netid  State      Recv-Q Send-Q Local Address:Port   Peer Address:Port
 tcp    ESTAB      0      0      10.0.0.5:443         10.0.0.1:12345""",
-                ["10.0.0.5"],
+                1,
+                "10.0.0.5:443",
                 id="remote",
             ),
         ],
     )
-    async def test_get_network_connections_success(self, mcp_client, mock_execute, host, mock_output, expected_content):
+    async def test_get_network_connections_success(
+        self, mcp_client, mock_execute, host, mock_output, expected_count, expected_local
+    ):
         """Test getting network connections with success."""
         mock_execute.return_value = (0, mock_output, "")
         result = await mcp_client.call_tool("get_network_connections", arguments={"host": host})
-        result_text = result.content[0].text.casefold()
+        content = result.structured_content["result"]
 
-        assert "active network connections" in result_text
-        assert all(content.casefold() in result_text for content in expected_content), (
-            "Did not find all expected values"
-        )
+        assert len(content) == expected_count
+        estab = next(conn for conn in content if conn["local_address"] == expected_local.split(":")[0])
+        assert estab["protocol"] == "TCP"
+        assert estab["local_port"] == expected_local.split(":")[1]
+        if host is None:
+            assert any(conn["state"] == "LISTEN" for conn in content)
 
     @pytest.mark.parametrize(
         ("return_value",),
@@ -160,13 +166,8 @@ tcp    ESTAB      0      0      10.0.0.5:443         10.0.0.1:12345""",
     async def test_get_network_connections_failure(self, mcp_client, mock_execute, return_value):
         """Test getting network connections when command fails or returns empty."""
         mock_execute.return_value = return_value
-        result = await mcp_client.call_tool("get_network_connections")
-        result_text = result.content[0].text.casefold()
-        expected = (
-            "error",
-            "neither ss nor netstat",
-        )
-        assert any(content.casefold() in result_text for content in expected)
+        with pytest.raises(ToolError, match="Error getting network connections"):
+            await mcp_client.call_tool("get_network_connections")
 
     async def test_get_network_connections_error(self, mcp_client, mock_execute):
         """Test getting network connections with general error."""

--- a/tests/tools/test_network.py
+++ b/tests/tools/test_network.py
@@ -40,7 +40,11 @@ class TestGetNetworkInterfaces:
                 "remote.example.com",
                 [
                     (0, "eth0             UP             192.168.1.100/24", ""),
-                    (0, "eth0: 1024 2048 0 0 0 0 0 0 512 1024 0 0 0 0 0 0", ""),
+                    (
+                        0,
+                        "Inter-|   Receive                                                |  Transmit\n face |bytes    packets\n  eth0: 1024 2048 0 0 0 0 0 0 512 1024 0 0 0 0 0 0",
+                        "",
+                    ),
                 ],
                 ["eth0"],
                 id="remote",
@@ -51,10 +55,31 @@ class TestGetNetworkInterfaces:
         """Test getting network interfaces with success."""
         mock_execute.side_effect = responses
         result = await mcp_client.call_tool("get_network_interfaces", arguments={"host": host})
-        result_text = result.content[0].text.casefold()
+        content = result.structured_content["result"]
 
-        assert "network interfaces" in result_text
-        assert all(iface in result_text for iface in expected_interfaces), "Did not find all expected values"
+        assert content is not None
+        assert len(content) == len(expected_interfaces)
+        names = [iface["name"] for iface in content]
+        assert names == sorted(expected_interfaces)
+
+        eth0 = next(iface for iface in content if iface["name"] == "eth0")
+        assert eth0["status"] == "UP"
+        assert "192.168.1.100/24" in eth0["addresses"]
+        if host is None:
+            assert eth0["rx_bytes"] == 9876543
+            assert eth0["tx_bytes"] == 5432100
+            assert eth0["rx_errors"] == 10
+            assert eth0["tx_errors"] == 20
+        else:
+            assert eth0["rx_bytes"] == 1024
+            assert eth0["tx_bytes"] == 512
+
+        if "lo" in expected_interfaces:
+            lo = next(iface for iface in content if iface["name"] == "lo")
+            assert lo["status"] == "UNKNOWN"
+            assert "127.0.0.1/8" in lo["addresses"]
+            assert lo["rx_bytes"] == 1234567
+
         assert mock_execute.call_count == 2
 
     async def test_get_network_interfaces_partial_failure(self, mcp_client, mock_execute):
@@ -65,10 +90,12 @@ class TestGetNetworkInterfaces:
         ]
 
         result = await mcp_client.call_tool("get_network_interfaces")
-        result_text = result.content[0].text.casefold()
+        content = result.structured_content["result"]
 
-        assert "network interfaces" in result_text
-        assert "eth0" in result_text
+        assert len(content) == 1
+        assert content[0]["name"] == "eth0"
+        assert content[0]["status"] == "UP"
+        assert content[0]["rx_bytes"] == 0
 
     async def test_get_network_interfaces_full_failure(self, mcp_client, mock_execute):
         """Test getting network interfaces with full failures."""
@@ -78,9 +105,7 @@ class TestGetNetworkInterfaces:
         ]
 
         result = await mcp_client.call_tool("get_network_interfaces")
-        result_text = result.content[0].text.casefold()
-
-        assert "network interfaces" in result_text
+        assert result.structured_content["result"] == []
 
     async def test_get_network_interfaces_error(self, mcp_client, mock_execute):
         """Test getting network interfaces with error."""

--- a/tests/tools/test_network.py
+++ b/tests/tools/test_network.py
@@ -181,34 +181,39 @@ class TestGetListeningPorts:
     """Test get_listening_ports function."""
 
     @pytest.mark.parametrize(
-        ("host", "mock_output", "expected_content"),
+        ("host", "mock_output", "expected_count", "expected_locals"),
         [
             pytest.param(
                 None,
                 """Netid  State      Recv-Q Send-Q Local Address:Port   Peer Address:Port
 tcp    LISTEN     0      128    0.0.0.0:80           0.0.0.0:*
 udp    UNCONN     0      0      0.0.0.0:53           0.0.0.0:*""",
-                ["0.0.0.0:80", "Total listening ports: 2"],
+                2,
+                ["0.0.0.0:80", "0.0.0.0:53"],
                 id="local",
             ),
             pytest.param(
                 "remote.host",
                 """Netid  State      Recv-Q Send-Q Local Address:Port   Peer Address:Port
 tcp    LISTEN     0      128    0.0.0.0:22           0.0.0.0:*""",
+                1,
                 ["0.0.0.0:22"],
                 id="remote",
             ),
         ],
     )
-    async def test_get_listening_ports_success(self, mcp_client, mock_execute, host, mock_output, expected_content):
+    async def test_get_listening_ports_success(
+        self, mcp_client, mock_execute, host, mock_output, expected_count, expected_locals
+    ):
         """Test getting listening ports with success."""
         mock_execute.return_value = (0, mock_output, "")
         result = await mcp_client.call_tool("get_listening_ports", arguments={"host": host})
-        result_text = result.content[0].text.casefold()
+        content = result.structured_content["result"]
 
-        assert all(content.casefold() in result_text for content in expected_content), (
-            "Did not find all expected values"
-        )
+        assert len(content) == expected_count
+        mcp_locals = {f"{port['local_address']}:{port['local_port']}" for port in content}
+        assert mcp_locals == set(expected_locals)
+        assert all(port["protocol"] in ("TCP", "UDP") for port in content)
 
     @pytest.mark.parametrize(
         ("return_value",),
@@ -220,16 +225,8 @@ tcp    LISTEN     0      128    0.0.0.0:22           0.0.0.0:*""",
     async def test_get_listening_ports_failure(self, mcp_client, mock_execute, return_value):
         """Test getting listening ports when command fails or returns empty."""
         mock_execute.return_value = return_value
-        result = await mcp_client.call_tool("get_listening_ports")
-        result_text = result.content[0].text.casefold()
-        expected_content = (
-            "error",
-            "neither ss nor netstat",
-        )
-
-        assert any(content.casefold() in result_text for content in expected_content), (
-            "Did not find any expected values"
-        )
+        with pytest.raises(ToolError, match="Error getting listening ports"):
+            await mcp_client.call_tool("get_listening_ports")
 
     async def test_get_listening_ports_error(self, mcp_client, mock_execute):
         """Test getting listening ports with general error."""


### PR DESCRIPTION
Straightforward port of the network.py tools to return structured output instead of string-formatted text.