### PR TITLE
Sync exec timeout with mcp app

### DIFF
--- a/mcp-app/src/run-script-app.tsx
+++ b/mcp-app/src/run-script-app.tsx
@@ -6,11 +6,12 @@ import {
   useApp,
 } from "@modelcontextprotocol/ext-apps/react";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { DEFAULT_REQUEST_TIMEOUT_MSEC } from "@modelcontextprotocol/sdk/shared/protocol";
 import { StrictMode, useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import {
   ExecuteScriptResultSchema,
-  GetExecutionStateResultSchema,
+  GetExecutionDetailsResultSchema,
   McpAppToolParamsSchema,
   McpAppToolResultSchema,
   type ExecutionState,
@@ -119,6 +120,9 @@ function RunScriptAppInner({
   const [executionState, setExecutionState] =
     useState<ExecutionState>("initial");
   const [executionResult, setExecutionResult] = useState<string>("");
+  const [executionTimeout, setExecutionTimeout] = useState<number>(
+    DEFAULT_REQUEST_TIMEOUT_MSEC,
+  );
 
   const validatedToolRequestParams = useMemo(() => {
     if (!toolRequestParams) {
@@ -155,9 +159,9 @@ function RunScriptAppInner({
   useEffect(() => {
     if (!validatedToolResult) return;
 
-    const getExecutionStateFromServer = async () => {
+    const getExecutionDetailsFromServer = async () => {
       const result = await app.callServerTool({
-        name: "get_execution_state",
+        name: "get_execution_details",
         arguments: {
           id: validatedToolResult.id,
         },
@@ -165,16 +169,20 @@ function RunScriptAppInner({
 
       if (result.isError) return;
 
-      const validatedResult = GetExecutionStateResultSchema.safeParse(
+      const validatedResult = GetExecutionDetailsResultSchema.safeParse(
         result.structuredContent,
       );
 
       if (validatedResult.success) {
         setExecutionState(validatedResult.data.state);
+
+        // Add 5 seconds grace period here so the timeout is always coming from
+        // the MCP server which contains more structured details
+        setExecutionTimeout(validatedResult.data.timeout * 1000 + 5000);
       }
     };
 
-    getExecutionStateFromServer();
+    getExecutionDetailsFromServer();
   }, [app, validatedToolResult]);
 
   const handleAccept = async () => {
@@ -187,10 +195,13 @@ function RunScriptAppInner({
     let outputToModel = "";
 
     try {
-      const result = await app.callServerTool({
-        name: "execute_script",
-        arguments: { id: validatedToolResult.id },
-      });
+      const result = await app.callServerTool(
+        {
+          name: "execute_script",
+          arguments: { id: validatedToolResult.id },
+        },
+        { timeout: executionTimeout },
+      );
 
       if (result.isError) {
         throw new Error(extractText(result));
@@ -209,14 +220,16 @@ function RunScriptAppInner({
         executeScriptResult,
       );
     } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : String(e);
+
       outputToModel = formatOutputForToolError(
         validatedToolRequestParams,
         validatedToolResult,
-        JSON.stringify(e),
+        errorMessage,
       );
 
       updatedExecutionState = "failure";
-      updatedExecutionResult = JSON.stringify(e);
+      updatedExecutionResult = errorMessage;
     }
 
     setExecutionState(updatedExecutionState);

--- a/mcp-app/src/types.ts
+++ b/mcp-app/src/types.ts
@@ -72,10 +72,11 @@ const ExecutionStateSchema = z.enum(executionState);
  */
 export type ExecutionState = z.infer<typeof ExecutionStateSchema>;
 
-export const GetExecutionStateResultSchema = z.object({
+export const GetExecutionDetailsResultSchema = z.object({
   state: ExecutionStateSchema,
+  timeout: z.number(), // in seconds
 });
 
-export type GetExecutionStateResult = z.infer<
-  typeof GetExecutionStateResultSchema
+export type GetExecutionDetailsResult = z.infer<
+  typeof GetExecutionDetailsResultSchema
 >;

--- a/src/linux_mcp_server/tools/__init__.py
+++ b/src/linux_mcp_server/tools/__init__.py
@@ -12,7 +12,7 @@ from linux_mcp_server.tools.network import get_network_interfaces
 from linux_mcp_server.tools.processes import get_process_info
 from linux_mcp_server.tools.processes import list_processes
 from linux_mcp_server.tools.run_script import execute_script
-from linux_mcp_server.tools.run_script import get_execution_state
+from linux_mcp_server.tools.run_script import get_execution_details
 from linux_mcp_server.tools.run_script import reject_script
 from linux_mcp_server.tools.run_script import run_script
 from linux_mcp_server.tools.run_script import run_script_interactive
@@ -42,7 +42,7 @@ __all__ = [
     "execute_script",
     "get_cpu_information",
     "get_disk_usage",
-    "get_execution_state",
+    "get_execution_details",
     "get_hardware_information",
     "get_journal_logs",
     "get_listening_ports",

--- a/src/linux_mcp_server/tools/run_script.py
+++ b/src/linux_mcp_server/tools/run_script.py
@@ -359,15 +359,15 @@ async def run_script_interactive(
 
 @mcp.tool(
     tags={"run_script", "mcp_apps_only", "hidden_from_model"},
-    title="Get the execution state with request ID",
-    description="Get the execution state with request ID",
+    title="Get the execution details with request ID",
+    description="Get the execution details with request ID",
     app=AppConfig(visibility=["app"]),
 )
 @log_tool_call
 @disallow_local_execution_in_containers
-async def get_execution_state(id: str):
+async def get_execution_details(id: str):
     script_detail = script_store.get_script_details(id)
-    return {"state": script_detail.state}
+    return {"state": script_detail.state, "timeout": CONFIG.command_timeout}
 
 
 def _pick_execution_tool(needs_confirmation: bool):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -49,7 +49,7 @@ RUN_SCRIPT_TOOLS = set(["run_script", "run_script_with_confirmation", "validate_
 RUN_SCRIPT_APP_TOOLS = set(
     [
         "execute_script",
-        "get_execution_state",
+        "get_execution_details",
         "reject_script",
         "run_script_interactive",
         "run_script",

--- a/tests/tools/test_run_script.py
+++ b/tests/tools/test_run_script.py
@@ -14,6 +14,7 @@ import pytest
 
 from fastmcp.exceptions import ToolError
 
+from linux_mcp_server.config import CONFIG
 from linux_mcp_server.config import Toolset
 from linux_mcp_server.connection.ssh import execute_command
 from linux_mcp_server.gatekeeper import GatekeeperResult
@@ -694,7 +695,7 @@ class TestExecuteScriptMCP:
 
 
 class TestRejectAndGetExecutionStateMCP:
-    """``reject_script`` and ``get_execution_state`` via ``app_client``."""
+    """``reject_script`` and ``get_execution_details`` via ``app_client``."""
 
     async def test_reject_script(
         self,
@@ -713,8 +714,8 @@ class TestRejectAndGetExecutionStateMCP:
         await app_client.call_tool("reject_script", {"id": "r"})
         assert script_store_fresh.get_script_details("r").state == "rejected-user"
 
-    async def test_get_execution_state(self, app_client: Any, script_store_fresh: ScriptStore) -> None:
-        """Expose the current lifecycle state string for UI polling."""
+    async def test_get_execution_details(self, app_client: Any, script_store_fresh: ScriptStore) -> None:
+        """Expose the current lifecycle state string and execution timeout for UI polling."""
         script_store_fresh._scripts["g"] = ScriptDetails(
             state="executing",
             description="d",
@@ -723,5 +724,21 @@ class TestRejectAndGetExecutionStateMCP:
             host="host",
             readonly=True,
         )
-        result = await app_client.call_tool("get_execution_state", {"id": "g"})
-        assert result.structured_content == {"state": "executing"}
+        result = await app_client.call_tool("get_execution_details", {"id": "g"})
+        assert result.structured_content == {"state": "executing", "timeout": 30}
+
+    async def test_get_execution_details_with_customized_timeout(
+        self, monkeypatch: pytest.MonkeyPatch, app_client: Any, script_store_fresh: ScriptStore
+    ) -> None:
+        """Expose the current lifecycle state string and execution timeout for UI polling."""
+        monkeypatch.setattr(CONFIG, "command_timeout", 60)
+        script_store_fresh._scripts["g"] = ScriptDetails(
+            state="executing",
+            description="d",
+            script="x",
+            script_type=SCRIPT_TYPE_BASH,
+            host="host",
+            readonly=True,
+        )
+        result = await app_client.call_tool("get_execution_details", {"id": "g"})
+        assert result.structured_content == {"state": "executing", "timeout": 60}


### PR DESCRIPTION
Add a get_execution_timeout server tool so the mcp-app can fetch the configured command timeout and apply it (plus a 5s grace period) to the execute_script call. This ensures long-running scripts aren't cut short by the SDK's default request timeout when the server allows more time.