### PR TITLE
ci: Upgrade to the latest mcp-publisher version

### DIFF
--- a/scripts/publish_mcp_registry.py
+++ b/scripts/publish_mcp_registry.py
@@ -76,7 +76,7 @@ def update_server_json(version):
 
 
 def main():
-    mcp_publisher_version = os.environ.get("MCP_PUBLISHER_VERSION", "v1.4.0")
+    mcp_publisher_version = os.environ.get("MCP_PUBLISHER_VERSION", "v1.7.9")
 
     github_ref = os.environ.get("GITHUB_REF", "")
     if not github_ref:


### PR DESCRIPTION
The 1.4.0 version we were using isn't compatible with the current registry, because of a change in OIDC usage.

See https://github.com/modelcontextprotocol/registry/pull/1229