### PR TITLE
fix: split lines parameter into first_lines and last_lines

### DIFF
--- a/src/linux_mcp_server/commands.py
+++ b/src/linux_mcp_server/commands.py
@@ -139,19 +139,22 @@ COMMANDS: Mapping[str, CommandGroup] = MappingProxyType(
         "journal_logs": CommandGroup(
             commands={
                 "default": CommandSpec(
-                    args=("journalctl", "-n", "{lines}", "--no-pager"),
+                    args=("journalctl", "--no-pager"),
                     optional_flags={
                         "unit": ("--unit", "{unit}"),
                         "priority": ("--priority", "{priority}"),
                         "since": ("--since", "{since}"),
                         "transport": ("_TRANSPORT={transport}",),
+                        "first_lines": ("-n", "+{first_lines}"),
+                        "last_lines": ("-n", "{last_lines}"),
                     },
                 ),
             }
         ),
         "read_log_file": CommandGroup(
             commands={
-                "default": CommandSpec(args=("tail", "-n", "{lines}", "{log_path}")),
+                "head": CommandSpec(args=("head", "-n", "{lines}", "{log_path}")),
+                "tail": CommandSpec(args=("tail", "-n", "{lines}", "{log_path}")),
             }
         ),
         # === Processes ===

--- a/src/linux_mcp_server/tools/logs.py
+++ b/src/linux_mcp_server/tools/logs.py
@@ -43,7 +43,8 @@ class Transport(StrEnum):
 
 
 async def _get_journal_logs(
-    lines: int,
+    first_lines: int | None = None,
+    last_lines: int | None = None,
     host: Host | None = None,
     unit: str | None = None,
     priority: str | None = None,
@@ -53,7 +54,8 @@ async def _get_journal_logs(
     """Execute journalctl command with optional filters.
 
     Args:
-        lines: Number of log lines to retrieve.
+        first_lines: Number of first log lines to retrieve (using -n +N).
+        last_lines: Number of last log lines to retrieve (using -n N).
         host: Optional remote host address.
         unit: Filter by systemd unit name.
         priority: Filter by priority level.
@@ -70,7 +72,8 @@ async def _get_journal_logs(
     cmd = get_command("journal_logs")
     return await cmd.run(
         host=host,
-        lines=lines,
+        first_lines=first_lines,
+        last_lines=last_lines,
         unit=unit,
         priority=priority,
         since=since,
@@ -112,7 +115,22 @@ async def get_journal_logs(
         Transport | None,
         "Filter by journal transport (e.g., 'audit' for audit logs, 'kernel' for kernel messages, 'syslog' for syslog messages)",
     ] = None,
-    lines: t.Annotated[int, Field(description="Number of log lines to retrieve. Default: 100", ge=1, le=10_000)] = 100,
+    first_lines: t.Annotated[
+        int | None,
+        Field(
+            description="Number of first log lines to retrieve after applying filters (journalctl -n +N). Mutually exclusive with last_lines.",
+            ge=1,
+            le=10_000,
+        ),
+    ] = None,
+    last_lines: t.Annotated[
+        int | None,
+        Field(
+            description="Number of last log lines to retrieve after applying filters (journalctl -n N). Default: 100. Mutually exclusive with first_lines.",
+            ge=1,
+            le=10_000,
+        ),
+    ] = None,
     host: Host = None,
 ) -> LogEntries:
     """Get systemd journal logs.
@@ -120,10 +138,27 @@ async def get_journal_logs(
     Retrieves entries from the systemd journal with optional filtering by unit,
     priority level, time range, and transport. Returns timestamped log messages.
 
+    Use first_lines to get the first N lines (e.g., with --since to get early entries).
+    Use last_lines to get the last N lines (default behavior if neither is specified).
+
     To get audit logs, use transport='audit'.
     """
+    # Validate mutually exclusive parameters
+    if first_lines is not None and last_lines is not None:
+        raise ToolError("Parameters 'first_lines' and 'last_lines' are mutually exclusive.")
+
+    # Default to last_lines=100 if neither is specified
+    if first_lines is None and last_lines is None:
+        last_lines = 100
+
     returncode, stdout, stderr = await _get_journal_logs(
-        lines=lines, host=host, unit=unit, priority=priority, since=since, transport=transport
+        first_lines=first_lines,
+        last_lines=last_lines,
+        host=host,
+        unit=unit,
+        priority=priority,
+        since=since,
+        transport=transport,
     )
 
     if returncode != 0:
@@ -157,14 +192,46 @@ async def read_log_file(
             examples=["/var/log/messages", "/var/log/secure", "/var/log/audit/audit.log", "/var/log/dnf.log"],
         ),
     ],
-    lines: t.Annotated[int, Field(description="Number of lines to retrieve from the end.", ge=1, le=10_000)] = 100,
+    first_lines: t.Annotated[
+        int | None,
+        Field(
+            description="Number of first lines to retrieve from the log file. Mutually exclusive with last_lines.",
+            ge=1,
+            le=10_000,
+        ),
+    ] = None,
+    last_lines: t.Annotated[
+        int | None,
+        Field(
+            description="Number of last lines to retrieve from the log file. Default: 100. Mutually exclusive with first_lines.",
+            ge=1,
+            le=10_000,
+        ),
+    ] = None,
     host: Host = None,
 ) -> LogEntries:
     """Read a specific log file.
 
-    Retrieves the last N lines from a log file. The file path must be in the
+    Retrieves lines from a log file. The file path must be in the
     allowed list configured via LINUX_MCP_ALLOWED_LOG_PATHS environment variable.
+
+    Use first_lines to get the first N lines from the beginning of the file.
+    Use last_lines to get the last N lines from the end (default behavior).
     """
+    # Validate mutually exclusive parameters
+    if first_lines is not None and last_lines is not None:
+        raise ToolError(
+            "Parameters 'first_lines' and 'last_lines' are mutually exclusive. "
+            "Use 'first_lines' to get the first N lines or 'last_lines' to get the last N lines, but not both."
+        )
+
+    # Default to last_lines=100 if neither is specified
+    if first_lines is None and last_lines is None:
+        last_lines = 100
+
+    # Determine which tail/head command to use
+    lines_value = first_lines if first_lines is not None else last_lines
+    use_head = first_lines is not None
     # Get allowed log paths from environment variable
     allowed_paths_env = CONFIG.allowed_log_paths
 
@@ -204,8 +271,10 @@ async def read_log_file(
 
         log_path_str = str(log_path)
 
-    cmd = get_command("read_log_file")
-    returncode, stdout, stderr = await cmd.run(host=host, lines=lines, log_path=log_path_str)
+    # Use head for first_lines, tail for last_lines
+    subcommand = "head" if use_head else "tail"
+    cmd = get_command("read_log_file", subcommand)
+    returncode, stdout, stderr = await cmd.run(host=host, lines=lines_value, log_path=log_path_str)
 
     if returncode != 0:
         if "Permission denied" in stderr:

--- a/tests/functional/logs_audit/test_get_journal_logs.py
+++ b/tests/functional/logs_audit/test_get_journal_logs.py
@@ -19,7 +19,8 @@ async def _assert_journal_logs_match(mcp_session, arguments, journalctl_cmd):
     # Fetch a wider window (100 lines) from the shell to ensure the tool's
     # output (usually 5 lines) is captured even if new logs arrive
     # during the millisecond gap between the tool call and the shell call.
-    wide_cmd = journalctl_cmd.replace("-n 5", "-n 100")
+    # Handle both -n 5 (last lines) and -n +5 (first lines)
+    wide_cmd = journalctl_cmd.replace("-n 5", "-n 100").replace("-n +5", "-n +100")
     actual_journal_logs = shell(wide_cmd, silent=True).stdout.strip()
 
     data = json.loads(response.content[0].text)
@@ -42,12 +43,12 @@ async def test_get_journal_logs(mcp_session):
     # 1. Happy path to show last 5 lines of the systemd-journald journal log
     await _assert_journal_logs_match(
         mcp_session,
-        arguments={"unit": "systemd-journald", "lines": 5},
+        arguments={"unit": "systemd-journald", "last_lines": 5},
         journalctl_cmd="journalctl -u systemd-journald -n 5 --no-pager",
     )
 
-    # 2. Call the tool with the lines=-1 argument. The tool returns an integer error
-    response = await mcp_session.call_tool("get_journal_logs", arguments={"unit": "systemd-journald", "lines": -1})
+    # 2. Call the tool with the last_lines=-1 argument. The tool returns an integer error
+    response = await mcp_session.call_tool("get_journal_logs", arguments={"unit": "systemd-journald", "last_lines": -1})
     assert response is not None
     response_text = response.content[0].text
     assert "1 validation error for call[get_journal_logs]" in response_text
@@ -56,7 +57,7 @@ async def test_get_journal_logs(mcp_session):
     # 3. Happy path to show last 5 lines of the systemd-journald journal log with priority=warning
     await _assert_journal_logs_match(
         mcp_session,
-        arguments={"unit": "systemd-journald", "lines": 5, "priority": "warning"},
+        arguments={"unit": "systemd-journald", "last_lines": 5, "priority": "warning"},
         journalctl_cmd="journalctl -u systemd-journald -n 5 -p warning --no-pager",
     )
 
@@ -65,7 +66,7 @@ async def test_get_journal_logs(mcp_session):
         mcp_session,
         arguments={
             "unit": "systemd-journald",
-            "lines": 5,
+            "last_lines": 5,
             "priority": "warning",
             "since": "1h ago",
         },
@@ -74,7 +75,7 @@ async def test_get_journal_logs(mcp_session):
 
     # 5. Call the tool with the invalid since argument
     response = await mcp_session.call_tool(
-        "get_journal_logs", arguments={"unit": "systemd-journald", "lines": 5, "since": "1h"}
+        "get_journal_logs", arguments={"unit": "systemd-journald", "last_lines": 5, "since": "1h"}
     )
     assert response is not None
     assert "Error reading journal logs: Failed to parse timestamp: 1h" in response.content[0].text
@@ -88,8 +89,21 @@ async def test_get_journal_logs_non_existing_unit(mcp_session):
 
     await _assert_journal_logs_match(
         mcp_session,
-        arguments={"unit": "superamazingunit", "lines": 5},
+        arguments={"unit": "superamazingunit", "last_lines": 5},
         journalctl_cmd="journalctl -n 5 --no-pager --unit superamazingunit",
+    )
+
+
+async def test_get_journal_logs_first_lines(mcp_session):
+    """
+    Verify that first_lines parameter works correctly with -n +N syntax.
+    """
+
+    # Test first_lines with since filter to get first N entries after a time
+    await _assert_journal_logs_match(
+        mcp_session,
+        arguments={"unit": "systemd-journald", "since": "1h ago", "first_lines": 5},
+        journalctl_cmd="journalctl -u systemd-journald --since '1h ago' -n +5 --no-pager",
     )
 
 
@@ -109,6 +123,6 @@ async def test_get_journal_logs_audit(mcp_session):
     # Happy path to show last 5 lines of the auditd journal log
     await _assert_journal_logs_match(
         mcp_session,
-        arguments={"lines": 5, "transport": "audit"},
+        arguments={"last_lines": 5, "transport": "audit"},
         journalctl_cmd="journalctl -n 5 --no-pager _TRANSPORT=audit",
     )

--- a/tests/functional/logs_audit/test_read_log_file.py
+++ b/tests/functional/logs_audit/test_read_log_file.py
@@ -21,7 +21,7 @@ async def test_read_existing_log_file(mcp_session):
         f.writelines(file_content)
     try:
         response = await mcp_session.call_tool(
-            "read_log_file", arguments={"log_path": "/tmp/existing_file.txt", "lines": 5}
+            "read_log_file", arguments={"log_path": "/tmp/existing_file.txt", "last_lines": 5}
         )
         assert response is not None
         data = json.loads(response.content[0].text)
@@ -51,7 +51,7 @@ async def test_read_non_existing_log_file(mcp_session):
     The file is present inside the allowed list of paths, but does not exist.
     """
     response = await mcp_session.call_tool(
-        "read_log_file", arguments={"log_path": "/tmp/nonexisting_file.txt", "lines": 5}
+        "read_log_file", arguments={"log_path": "/tmp/nonexisting_file.txt", "last_lines": 5}
     )
     assert response is not None
     assert "Log file not found: /tmp/nonexisting_file.txt" in response.content[0].text
@@ -68,7 +68,7 @@ async def test_read_not_allowed_log_file(mcp_session):
     The file is not present inside the allowed list of paths.
     """
     response = await mcp_session.call_tool(
-        "read_log_file", arguments={"log_path": "/tmp/not_allowed_file.txt", "lines": 5}
+        "read_log_file", arguments={"log_path": "/tmp/not_allowed_file.txt", "last_lines": 5}
     )
     assert response is not None
     assert "Access to log file '/tmp/not_allowed_file.txt' is not allowed." in response.content[0].text
@@ -91,6 +91,38 @@ async def test_read_log_file_empty_argument(mcp_session):
 
 @pytest.mark.parametrize(
     "mcp_session",
+    [{"LINUX_MCP_ALLOWED_LOG_PATHS": "/tmp/test_first_lines.txt"}],
+    indirect=True,
+)
+async def test_read_log_file_first_lines(mcp_session):
+    """
+    Verify that first_lines parameter works correctly with head command.
+    """
+    file_content = "\n".join([f"Line {i}" for i in range(1, 11)])  # 10 lines
+    with open("/tmp/test_first_lines.txt", "w", encoding="utf-8") as f:
+        f.write(file_content)
+    try:
+        response = await mcp_session.call_tool(
+            "read_log_file", arguments={"log_path": "/tmp/test_first_lines.txt", "first_lines": 3}
+        )
+        assert response is not None
+        data = json.loads(response.content[0].text)
+
+        # Should get the first 3 lines
+        entries = data.get("entries", [])
+        assert len(entries) == 3
+        assert entries[0] == "Line 1"
+        assert entries[1] == "Line 2"
+        assert entries[2] == "Line 3"
+    finally:
+        try:
+            os.remove("/tmp/test_first_lines.txt")
+        except FileNotFoundError:
+            pass
+
+
+@pytest.mark.parametrize(
+    "mcp_session",
     [{"LINUX_MCP_ALLOWED_LOG_PATHS": "/var/log/boot.log,/tmp/existing_file.txt,/tmp/nonexisting_file.txt"}],
     indirect=True,
 )
@@ -106,7 +138,9 @@ async def test_read_unauthorized_log_file(mcp_session):
     Verify the response contains the error message when the file is not authorized.
     The file is present inside the allowed list of paths, but the user does not have permission to read it.
     """
-    response = await mcp_session.call_tool("read_log_file", arguments={"log_path": "/var/log/boot.log", "lines": 5})
+    response = await mcp_session.call_tool(
+        "read_log_file", arguments={"log_path": "/var/log/boot.log", "last_lines": 5}
+    )
     assert response is not None
     assert "Permission denied reading log file: /var/log/boot.log" in response.content[0].text
     # TODO Finish the test case, think about multihost testing for the MCP

--- a/tests/tools/test_logs.py
+++ b/tests/tools/test_logs.py
@@ -23,7 +23,7 @@ class TestGetJournalLogs:
     @pytest.mark.parametrize(
         "params, expected_args, expected_fields",
         [
-            # Default parameters
+            # Default parameters (defaults to last_lines=100)
             (
                 {},
                 ["-n", "100", "--no-pager"],
@@ -47,16 +47,28 @@ class TestGetJournalLogs:
                 ["--since", "today"],
                 {"unit": None},
             ),
-            # Custom line count
+            # Custom last_lines count
             (
-                {"lines": 50},
+                {"last_lines": 50},
                 ["-n", "50"],
                 {"unit": None},
             ),
-            # All filters combined
+            # Custom first_lines count
             (
-                {"unit": "nginx.service", "priority": "err", "since": "today", "lines": 50},
+                {"first_lines": 25},
+                ["-n", "+25"],
+                {"unit": None},
+            ),
+            # All filters combined with last_lines
+            (
+                {"unit": "nginx.service", "priority": "err", "since": "today", "last_lines": 50},
                 ["--unit", "nginx.service", "--priority", "err", "--since", "today", "-n", "50"],
+                {"unit": "nginx.service"},
+            ),
+            # All filters combined with first_lines
+            (
+                {"unit": "nginx.service", "priority": "err", "since": "today", "first_lines": 50},
+                ["--unit", "nginx.service", "--priority", "err", "--since", "today", "-n", "+50"],
                 {"unit": "nginx.service"},
             ),
             # Transport filter (audit)
@@ -71,7 +83,7 @@ class TestGetJournalLogs:
                 {"unit": None},
             ),
             (
-                {"transport": "audit", "priority": "err", "lines": 50},
+                {"transport": "audit", "priority": "err", "last_lines": 50},
                 ["_TRANSPORT=audit", "--priority", "err", "-n", "50"],
                 {"unit": None},
             ),
@@ -169,6 +181,11 @@ class TestGetJournalLogs:
         assert content["lines_count"] == 3
         assert len(content["entries"]) == 3
 
+    async def test_get_journal_logs_mutually_exclusive_lines(self, mcp_client, mock_execute_with_fallback):
+        """Test get_journal_logs rejects both first_lines and last_lines."""
+        with pytest.raises(ToolError, match="mutually exclusive"):
+            await mcp_client.call_tool("get_journal_logs", {"first_lines": 10, "last_lines": 20})
+
 
 class TestReadLogFile:
     """Tests for read_log_file tool."""
@@ -201,18 +218,40 @@ class TestReadLogFile:
         assert "-n" in cmd_args
         assert "100" in cmd_args
 
-    async def test_read_log_file_custom_lines(self, mcp_client, mock_execute_with_fallback, setup_log_file):
-        """Test read_log_file with custom line count."""
+    async def test_read_log_file_custom_last_lines(self, mcp_client, mock_execute_with_fallback, setup_log_file):
+        """Test read_log_file with custom last_lines count."""
         log_file = setup_log_file()
         mock_execute_with_fallback.return_value = (0, "Test log content\nLine 2", "")
 
-        result = await mcp_client.call_tool("read_log_file", {"log_path": log_file, "lines": 50})
+        result = await mcp_client.call_tool("read_log_file", {"log_path": log_file, "last_lines": 50})
         content = result.structured_content
 
         assert content["lines_count"] == 2
 
         cmd_args = mock_execute_with_fallback.call_args[0][0]
         assert "50" in cmd_args
+        assert "tail" in cmd_args
+
+    async def test_read_log_file_first_lines(self, mcp_client, mock_execute_with_fallback, setup_log_file):
+        """Test read_log_file with first_lines to get beginning of file."""
+        log_file = setup_log_file()
+        mock_execute_with_fallback.return_value = (0, "Test log content\nLine 2", "")
+
+        result = await mcp_client.call_tool("read_log_file", {"log_path": log_file, "first_lines": 25})
+        content = result.structured_content
+
+        assert content["lines_count"] == 2
+
+        cmd_args = mock_execute_with_fallback.call_args[0][0]
+        assert "25" in cmd_args
+        assert "head" in cmd_args
+
+    async def test_read_log_file_mutually_exclusive_lines(self, mcp_client, mock_execute_with_fallback, setup_log_file):
+        """Test read_log_file rejects both first_lines and last_lines."""
+        log_file = setup_log_file()
+
+        with pytest.raises(ToolError, match="mutually exclusive"):
+            await mcp_client.call_tool("read_log_file", {"log_path": log_file, "first_lines": 10, "last_lines": 20})
 
     async def test_read_log_file_no_allowed_paths(self, mcp_client, mock_allowed_log_paths):
         """Test read_log_file when no allowed paths are configured."""


### PR DESCRIPTION
Fixes #472

Split the 'lines' parameter in get_journal_logs into 'first_lines' and 'last_lines' to make journalctl -n vs -n +N behavior explicit.

Changes:
- Updated get_journal_logs tool to accept first_lines and last_lines instead of lines parameter
- first_lines uses 'journalctl -n +N' to get first N lines after filters
- last_lines uses 'journalctl -n N' to get last N lines (default: 100)
- Parameters are mutually exclusive with validation
- Updated command registry to support both optional_flags
- Updated all unit and functional tests