### PR TITLE
fix(ci): remove unnecessary HOME override in setup-uv job

### DIFF
--- a/.gitlab/ci/eval-gatekeeper.yml
+++ b/.gitlab/ci/eval-gatekeeper.yml
@@ -4,8 +4,6 @@
 setup-uv:
   stage: setup
   image: images.paas.redhat.com/it-cloud-ocp-proxy-lib/python:3.14
-  variables:
-    HOME: "$CI_PROJECT_DIR"
   script:
     # Install uv
     - export PYTHONUSERBASE=$CI_PROJECT_DIR/.local


### PR DESCRIPTION
Remove HOME override to prevent Git checkout failure due to .gitconfig being written to a non-existent project directory. PYTHONUSERBASE already controls the pip install --user location.

---

Error in gitlab

```
Running with gitlab-runner 19.1.1 (24b9b726)
  on rhel-lightspeed-runner-5d59cbdb6d-5xpzm OrXb0DkOm, system ID: r_gAFfihldgova
Resolving secrets
Preparing the "kubernetes" executor 00:00
Using Kubernetes namespace: rhel-lightspeed--pipeline
Using Kubernetes executor with image images.paas.redhat.com/it-cloud-ocp-proxy-lib/python:3.14 ...
Using attach strategy to execute scripts...
Using effective pull policy of [] for container build
Using effective pull policy of [] for container helper
Using effective pull policy of [] for container init-permissions
Preparing environment 00:07
Using FF_USE_POD_ACTIVE_DEADLINE_SECONDS, the Pod activeDeadlineSeconds will be set to the job timeout: 1h0m0s...
Waiting for pod rhel-lightspeed--pipeline/runner-orxb0dkom-project-161927-concurrent-0-3oicexg4 to be running on the node ip-10-30-46-222.ec2.internal, status is Pending
Waiting for pod rhel-lightspeed--pipeline/runner-orxb0dkom-project-161927-concurrent-0-3oicexg4 to be running on the node ip-10-30-46-222.ec2.internal, status is Pending
	ContainersNotReady: "containers with unready status: [build helper]"
	ContainersNotReady: "containers with unready status: [build helper]"
Running on runner-orxb0dkom-project-161927-concurrent-0-3oicexg4 via rhel-lightspeed-runner-5d59cbdb6d-5xpzm...
Getting source from Git repository 00:01
error: could not lock config file /builds/rhel-lightspeed/mcp/linux-mcp-server/.gitconfig: No such file or directory
Cleaning up project directory and file based variables 00:00
ERROR: Job failed: command terminated with exit code 255
```