### PR TITLE
Pin FastMCP to version 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.10"
 # no longer getting security fixes.
 dependencies = [
     "asyncssh[bcrypt] >= 2.22.0",
-    "fastmcp >= 3.2.4",
+    "fastmcp >= 3.2.4, < 4",
     "httpx>=0.28.1",
     "pydantic-settings >= 2.12.0",
     "pydantic >= 2.12.5",

--- a/uv.lock
+++ b/uv.lock
@@ -1393,7 +1393,7 @@ test = [
 requires-dist = [
     { name = "asyncssh", extras = ["bcrypt"], specifier = ">=2.22.0" },
     { name = "fakeredis", specifier = "<2.35" },
-    { name = "fastmcp", specifier = ">=3.2.4" },
+    { name = "fastmcp", specifier = ">=3.2.4,<4" },
     { name = "google-auth", marker = "extra == 'gcp'", specifier = ">=2.40.0" },
     { name = "gssapi", marker = "extra == 'gssapi'", specifier = ">=1.11.1" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
Our server middleware will require changes to handle FastMCP 4 and Version 2 of the Python SDK. Until we do that, pin FastMCP to version 3.