### PR TITLE
docs: refresh AGENTS.md and slim CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -38,70 +38,20 @@ reviews:
     - "!**/.coverage"
     - "!**/uv.lock"
 
+  # Conventions and architecture live in AGENTS.md, which CodeRabbit already
+  # ingests. Keep these rules to review-stage behavior only — what to skip, and
+  # facts a reviewer needs but an author doesn't act on.
   path_instructions:
     - path: "src/**/*.py"
-      # NOTE(major): Adjust the read-only line at the top when
-      # write operations are allowed.
       instructions: |
-        Focus on security and architecture:
-        - CRITICAL: All operations MUST be read-only. Flag any write operations.
-        - Check for TOCTOU race conditions (use try-except, not check-then-use)
-        - psutil exceptions pattern: except (psutil.NoSuchProcess, psutil.AccessDenied)
-        - Verify async/await patterns (no blocking calls in async functions)
-        - Ensure proper exception handling with graceful degradation
-        - Error messages must be clear enough for LLMs to understand and act on
-        - Check input validation before shell commands (command injection)
-        - Verify MCP decorator order: @mcp.tool, @log_tool_call, @disallow_local_execution_in_containers
-        - Host parameter pattern: host: Host | None = None (supports local and remote)
-        - Resource cleanup: Verify SSH connections use context managers
-        - Timeout handling: All network/SSH operations must have timeouts
-        - Container safety: Flag operations that won't work in containers without explicit checks
-        - Don't nitpick style (ruff handles) or types (pyright validates)
-
-    - path: "src/**/config.py"
-      instructions: |
-        Configuration validation:
-        - Centralize derived config logic (defaults, path resolution) in config class
-        - Validate environment variables at startup, not lazily
-        - Check for secure defaults
-
-    - path: "src/**/connection/*.py"
-      instructions: |
-        SSH/connection handling:
-        - All SSH operations must have timeouts
-        - Prefer library-native async features (asyncssh timeout param) over wrappers (asyncio.wait_for)
-        - Connection errors must include host information for debugging
-        - Resource cleanup: Use context managers for all connections
-        - Key handling: No plaintext passwords, only key-based auth
+        Don't nitpick style (ruff handles it) or types (pyright validates them).
 
     - path: "tests/**/*.py"
       instructions: |
-        Focus on test quality and meaningfulness:
-        - Tests should verify behavior, not just chase coverage. A test that doesn't assert meaningful outcomes is worse than no test.
-        - Prefer parameterized tests over duplicate test functions
-        - Mock specs should be provided: AsyncMock(spec=SomeClass)
-        - Use pytest.raises with nullcontext() pattern, not boolean flags
-        - Use fixtures for reusable test components, not helper functions
-        - Check for edge cases: process disappearing, permission denied, empty output
-        - Verify both local (psutil) and remote (SSH) code paths tested
-        - Don't nitpick coverage percentages (CI enforces 70%+ overall, 100% patch)
-
-    - path: "pyproject.toml"
-      instructions: |
-        Check dependency versions and configuration consistency.
-        Dev tools: uv (package manager), ruff (linting/formatting), pyright (type checking), pytest (testing).
+        Don't nitpick coverage percentages (CI enforces 70%+ overall, 100% patch).
 
     - path: ".github/workflows/**"
-      instructions: "Validate workflow syntax and security (no secrets in logs)"
-
-    - path: "Makefile"
-      instructions: |
-        Makefile validation:
-        - .PHONY declarations for all non-file targets
-        - Avoid flags that are already defaults
-
-    - path: "Containerfile"
-      instructions: "Use Podman + Containerfile conventions (not Docker + Dockerfile)"
+      instructions: "Flag any secrets exposed in logs."
 
 chat:
   auto_reply: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,13 @@
 # Linux MCP Server
 
-Read-only MCP server for Linux system diagnostics.
+MCP server for Linux system diagnostics. Two operating modes, selected by the
+`LINUX_MCP_TOOLSET` env var:
+
+- `fixed` (default) — a fixed set of **read-only** diagnostic tools.
+- `run_script` / `both` — additionally exposes **guarded command execution**
+  (`run_script`), which may modify the system. Writes there are permitted only
+  because the gatekeeper, user confirmation, and sandbox guard that path — no
+  other tool has that backstop.
 
 ## Commands
 
@@ -14,30 +21,52 @@ make verify                  # All checks (required before commit)
 
 ## Project Layout
 
-- `src/linux_mcp_server/tools/` - MCP tools (logs, network, processes, services, storage, system_info)
-- `src/linux_mcp_server/commands.py` - Command definitions
+- `src/linux_mcp_server/tools/` - MCP tools (logs, network, processes, services, storage, system_info, run_script)
+- `src/linux_mcp_server/commands.py` - Command definitions (the `COMMANDS` registry)
 - `src/linux_mcp_server/formatters.py` / `parsers.py` - Output formatting and parsing
+- `src/linux_mcp_server/gatekeeper/` - LLM-based safety validation of `run_script` scripts
+- `src/linux_mcp_server/auth.py` / `auth_policy.py` - Authentication and authorization policy
+- `src/linux_mcp_server/audit.py` - Audit logging of executed operations
+- `src/linux_mcp_server/connection/ssh.py` - Remote execution over SSH
+- `src/linux_mcp_server/config.py` / `execution_context.py` / `toolset.py` - Config, per-call context, toolset selection
 - `tests/` - Mirrors src structure
 
 ## Rules
 
 **Code:** PEP 8, type hints required, async/await for I/O, 120 char max, prefer Pydantic over dataclasses
 
+- Tools take `host: Host | None` so they work both locally and over SSH
+- All network/SSH operations must have timeouts; prefer asyncssh-native timeouts over `asyncio.wait_for`
+- SSH uses key-based auth only (no plaintext passwords); connection and command errors must include the host for debugging
+- Validate config and env vars at startup (Pydantic `model_validator`), not lazily; use secure defaults
+- Error messages must be clear enough for an LLM to understand and act on
+- Operations that can't work in a container are gated by `@disallow_local_execution_in_containers`
+
 **Testing:**
 - Run `make verify` before committing
+- Tests should verify behavior, not just chase coverage — a test that asserts nothing meaningful is worse than none
 - Use parameterized tests and fixtures (shared fixtures go in `conftest.py`)
 - Use pytest-mock (`mocker` fixture) for mocking instead of `unittest.mock` imports
 - Use `autospec=True` when patching; `spec=<object>` with Mock
+- Cover both local (command/parser) and remote (SSH) code paths
 - 100% patch coverage for new code
 - Do not use `@pytest.mark.asyncio` for tests. It's not necessary because the project uses `asyncio_mode = "auto"`
 
 **Security (Critical):**
-- All tools must be read-only with `readOnlyHint=True`
-- Validate all input, use allowlists for file paths, sanitize shell params
+- Fixed-mode tools (everything except `run_script`) must be **strictly read-only**
+  (`readOnlyHint=True`) and self-sufficient: no gatekeeper, confirmation, or sandbox
+  protects them. Never interpolate untrusted input (args, hostnames, file contents)
+  into a shell command — pass argument vectors and validate/escape inputs.
+- Validate all input; use allowlists for file paths.
+- `run_script` may modify the system, but only behind the gatekeeper + user
+  confirmation + sandbox. Those guardrails must stay intact and fail closed — a
+  script must never reach execution having bypassed validation or confirmation.
+- The gatekeeper and auth policy must **fail closed**: any validation error,
+  timeout, or missing/invalid policy denies rather than allows.
 
 ## Adding Tools
 
-1. Create tool in `src/linux_mcp_server/tools/` using `@mcp.tool()`, `@log_tool_call`, `@disallow_local_execution_in_containers` decorators
+1. Create tool in `src/linux_mcp_server/tools/` using `@mcp.tool()`, `@log_tool_call`, `@disallow_local_execution_in_containers` decorators (in that order)
 2. Register command in `commands.py`
 3. Write tests in `tests/tools/`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
AGENTS.md was written for the old read-only-only model. Update it for the two toolset modes (fixed / run_script / both), document the guarded run_script execution path (gatekeeper + confirmation + sandbox), and add the gatekeeper, auth, audit, and connection modules to the layout.

Move substantive engineering and security conventions into AGENTS.md so PRs are correct before review, and trim .coderabbit.yaml path rules down to review-stage-only behavior (skip style/type/coverage nitpicks) since CodeRabbit already ingests AGENTS.md. Symlink CLAUDE.md to AGENTS.md.