### PR TITLE
ci: add nightly dependency canary

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,232 @@
+name: Dependency Canary
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
+  FORCE_COLOR: 1
+
+jobs:
+  # Runs the latest, unvetted dependency releases (installs and tests execute
+  # arbitrary third-party code). Kept to contents:read with no persisted
+  # credentials so a compromised release cannot reach a write-capable token.
+  # The privileged issue filing happens in the separate `report` job below,
+  # which runs no third-party code.
+  test:
+    name: Canary - Latest Dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      outcome: ${{ steps.result.outputs.outcome }}
+      stage: ${{ steps.result.outputs.stage }}
+
+    env:
+      # pyproject.toml sets `exclude-newer = "7 days"` to require a minimum
+      # package age. The canary deliberately wants the absolute latest releases
+      # (what a fresh `uv tool install` would pull), so disable the cutoff for
+      # every uv command. (`false` requires uv >= 0.11.24.)
+      UV_EXCLUDE_NEWER: "false"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Don't leave the workflow token in the git config where the
+          # untrusted dependency code run below could read it.
+          persist-credentials: false
+
+      - name: Install Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          prune-cache: false
+
+      # Each stage can break with the latest dependencies: resolution
+      # (uv lock), installation/build (uv sync), or the tests themselves. Let
+      # each one fail without aborting the job, and skip later stages once one
+      # breaks, so `report` can file an issue naming the stage that failed.
+      - name: Upgrade lock file
+        id: lock
+        continue-on-error: true
+        run: uv lock --upgrade
+
+      - name: Install dependencies
+        id: sync
+        if: steps.lock.outcome == 'success'
+        continue-on-error: true
+        run: uv sync --locked --group test
+
+      - name: Run tests
+        id: tests
+        if: steps.sync.outcome == 'success'
+        continue-on-error: true
+        run: uv run --locked pytest
+
+      - name: Upload upgraded lock file
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: upgraded-lock
+          path: uv.lock
+
+      # Report the first stage that broke. A skipped later stage has outcome
+      # 'skipped', which is neither 'success' nor 'failure'.
+      - name: Determine result
+        id: result
+        run: |
+          if [ "${{ steps.lock.outcome }}" = "failure" ]; then
+            stage=lock
+          elif [ "${{ steps.sync.outcome }}" = "failure" ]; then
+            stage=sync
+          elif [ "${{ steps.tests.outcome }}" = "failure" ]; then
+            stage=tests
+          else
+            stage=
+          fi
+          if [ -n "$stage" ]; then
+            echo "outcome=failure" >> "$GITHUB_OUTPUT"
+          else
+            echo "outcome=success" >> "$GITHUB_OUTPUT"
+          fi
+          echo "stage=$stage" >> "$GITHUB_OUTPUT"
+
+  # Files/updates/closes the canary issue. Holds issues:write but runs only
+  # first-party code: a clean checkout, an artifact download, and github-script.
+  report:
+    name: Report canary result
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download upgraded lock file
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: upgraded-lock
+
+      # Write to a file rather than a step output: the diff can be large, and
+      # both $GITHUB_OUTPUT and the issue body have size caps. The script reads
+      # and truncates it below.
+      - name: Show lock file changes
+        run: git diff uv.lock > "$RUNNER_TEMP/lock.diff"
+
+      - name: Manage canary issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const label = 'dependency-canary';
+            const outcome = '${{ needs.test.outputs.outcome }}';
+            const stage = '${{ needs.test.outputs.stage }}';
+            const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+
+            // Keep the diff well under the 65536-char issue/comment body cap,
+            // leaving headroom for the surrounding markdown. The full lock file
+            // is always available as the run's "upgraded-lock" artifact.
+            const MAX_DIFF = 50000;
+            const rawDiff = require('fs')
+              .readFileSync('${{ runner.temp }}/lock.diff', 'utf8')
+              .trimEnd();
+            const lockDiff = rawDiff === ''
+              ? '(no lock file changes)'
+              : rawDiff.length > MAX_DIFF
+                ? `${rawDiff.slice(0, MAX_DIFF)}\n... truncated; download the "upgraded-lock" artifact from the run.`
+                : rawDiff;
+
+            const stageMessage = {
+              lock: 'Dependency resolution failed (`uv lock --upgrade`) with the latest dependencies.',
+              sync: 'Installing dependencies failed (`uv sync`) with the latest dependencies.',
+              tests: 'Tests failed with the latest resolved dependencies.',
+            }[stage] || 'The canary failed with the latest dependencies.';
+
+            // Ensure label exists
+            try {
+              await github.rest.issues.getLabel({ ...context.repo, name: label });
+            } catch {
+              await github.rest.issues.createLabel({
+                ...context.repo,
+                name: label,
+                color: 'D93F0B',
+                description: 'Nightly dependency canary failure',
+              });
+            }
+
+            // Find existing open canary issue. listForRepo also returns pull
+            // requests (PRs are issues in the API), so skip anything with a
+            // pull_request field to avoid ever commenting on or closing a PR.
+            const { data: issues } = await github.rest.issues.listForRepo({
+              ...context.repo,
+              labels: label,
+              state: 'open',
+              per_page: 100,
+            });
+            const existing = issues.find((i) => !i.pull_request);
+
+            if (outcome === 'failure') {
+              const body = `## Dependency canary failure
+
+            ${stageMessage}
+
+            **Workflow run:** ${runUrl}
+
+            <details>
+            <summary><code>git diff uv.lock</code></summary>
+
+            \`\`\`diff
+            ${lockDiff}
+            \`\`\`
+
+            </details>`;
+
+              if (existing) {
+                await github.rest.issues.createComment({
+                  ...context.repo,
+                  issue_number: existing.number,
+                  body,
+                });
+                core.info(`Updated existing issue #${existing.number}`);
+              } else {
+                const { data: created } = await github.rest.issues.create({
+                  ...context.repo,
+                  title: 'Dependency canary: failing with latest dependencies',
+                  labels: [label],
+                  body,
+                });
+                core.info(`Created new canary issue #${created.number}`);
+              }
+            } else if (existing) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: existing.number,
+                body: `The canary is passing again with the latest dependencies. Closing.\n\n**Workflow run:** ${runUrl}`,
+              });
+              await github.rest.issues.update({
+                ...context.repo,
+                issue_number: existing.number,
+                state: 'closed',
+              });
+              core.info(`Closed issue #${existing.number}`);
+            } else {
+              core.info('Tests passed and no open canary issue. Nothing to do.');
+            }
+
+      - name: Fail if the canary failed
+        if: needs.test.outputs.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
Add a nightly canary workflow that runs unit tests against the latest resolved dependencies (via uv lock --upgrade). On failure, it files a GitHub issue (or updates an existing one) with the test output and lock file diff. On success, it auto-closes any open canary issue.