### PR TITLE
Fix formatting for check_run_script.py

### DIFF
--- a/src/linux_mcp_server/gatekeeper/check_run_script.py
+++ b/src/linux_mcp_server/gatekeeper/check_run_script.py
@@ -247,7 +247,8 @@ async def check_run_script(
                     GatekeeperResult(
                         status=GatekeeperStatus.MALICIOUS,
                         detail=f"{field} contains prompt delimiter '{pattern}'",
-                    ), GatekeeperStats()
+                    ),
+                    GatekeeperStats(),
                 )
 
     prompt = PROMPT.format(


### PR DESCRIPTION
When the recent security fixes were merged, a formatting error slipped in - fix it to restore CI workingness.