### PR TITLE
ci: don't run functional tests on changes to irrelevant directories

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -4,10 +4,18 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - ".tekton/**"
+      - "docs/**"
+      - "eval/**"
   pull_request_target:
     types: [opened, synchronize, labeled]
     branches:
       - main
+    paths-ignore:
+      - ".tekton/**"
+      - "docs/**"
+      - "eval/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The functional tests require manual approval for changes for non-core contributors and wait for a test system to be assigned for a long time, so skip them for changes that obviously won't affect the result.