### PR TITLE
chore(renovate): force RPM lockfile updates onto a different branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rhel-lightspeed/renovate-config"],
+  "rpm-lockfile": {
+    "lockFileMaintenance": {
+      "branchTopic": "rpm-lockfile-refresh"
+    }
+  },
   "pip-compile": {
     "enabled": true
   },


### PR DESCRIPTION
The fork of Renovate used in Mintmaker contains a somewhat hacky rpm-lockfile manager that interacts badly with other lockfile updates.

 * All lockfile updates get a "Refresh RPM lockfiles" PR title
 * All lockfile updates get the schedule that was set for rpm-lockfile updates in the global MintMaker config.
 * The cloned branches that are created for security updates also include non-rpm-lockfile updates.

We can fix this by forcing the updates for the rpm-lockfile manager onto a different branch - then the rpm-lockfile updates will get an entirely different set of PRs, and general lockfile updates (in particular uv.lock changes) will sail along without interference.

This is likely upstreamable, but we'll try it locally for now.